### PR TITLE
dev: content list item component

### DIFF
--- a/src/components/MVP/ContentListGroup/ContentListGroup.module.scss
+++ b/src/components/MVP/ContentListGroup/ContentListGroup.module.scss
@@ -1,0 +1,49 @@
+@import 'styles/uswdsDependencies';
+@import 'styles/mvp/mixins';
+.contentLinks {
+  :global {
+    .section__links {
+      h3 {
+        font-size: size('heading', 'sm');
+        margin-bottom: 0.5em;
+      }
+    }
+    .section-links__item {
+      border-top: 1px solid color('base-lighter');
+      color: color('primary') !important;
+      text-decoration: none !important;
+
+      &:hover {
+        background: color('gray-cool-2');
+        color: color('primary-dark') !important;
+      }
+
+      &:last-child {
+        border-bottom: 1px solid color('base-lighter');
+      }
+
+      p {
+        font-size: size('body', '2xs');
+        line-height: lh('body', 3);
+        margin-bottom: units(2);
+        color: #71767a;
+      }
+
+      h3,
+      p {
+        margin-top: units(2);
+      }
+
+      h3 {
+        font-weight: font-weight('bold');
+        line-height: lh('heading', 2);
+        margin-bottom: 0;
+
+        @include at-media('tablet') {
+          margin-bottom: units(2);
+          padding-right: units(2);
+        }
+      }
+    }
+  }
+}

--- a/src/components/MVP/ContentListGroup/ContentListGroup.test.tsx
+++ b/src/components/MVP/ContentListGroup/ContentListGroup.test.tsx
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import ContentListGroup from './ContentListGroup'
+
+describe('Content List Group component', () => {
+  beforeEach(() => {
+    render(
+      <ContentListGroup heading="List Title">
+        <div className="test-child">Test Content</div>
+      </ContentListGroup>
+    )
+  })
+
+  it('renders the h2', () => {
+    expect(
+      screen.getByRole('heading', { name: 'List Title' })
+    ).toBeInTheDocument()
+  })
+  it('renders the children', () => {
+    expect(screen.getByText('Test Content')).toBeInTheDocument()
+  })
+})

--- a/src/components/MVP/ContentListGroup/ContentListGroup.tsx
+++ b/src/components/MVP/ContentListGroup/ContentListGroup.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styles from './ContentListGroup.module.scss'
+
+interface ContentListGroupProps {
+  children: React.ReactNode
+  heading?: string
+  className?: string
+}
+
+const ContentListGroup = ({
+  children,
+  heading,
+  className,
+}: ContentListGroupProps): React.ReactElement => {
+  return (
+    <div className={`grid-container usa-prose contentLinks ${className}`}>
+      <div className={`grid-row grid-gap contentLinks ${styles.contentLinks}`}>
+        <div className="tablet:grid-col-8">
+          <h2 className="font-heading-md text-normal border-top padding-top-2">
+            {heading}
+          </h2>
+          <div className="section__links margin-top-3">{children}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ContentListGroup

--- a/src/components/MVP/ContentListGroup/ContentListGroup.tsx
+++ b/src/components/MVP/ContentListGroup/ContentListGroup.tsx
@@ -4,16 +4,14 @@ import styles from './ContentListGroup.module.scss'
 interface ContentListGroupProps {
   children: React.ReactNode
   heading?: string
-  className?: string
 }
 
 const ContentListGroup = ({
   children,
   heading,
-  className,
 }: ContentListGroupProps): React.ReactElement => {
   return (
-    <div className={`grid-container usa-prose contentLinks ${className}`}>
+    <div data-testid="contentListGroup" className="grid-container usa-prose">
       <div className={`grid-row grid-gap contentLinks ${styles.contentLinks}`}>
         <div className="tablet:grid-col-8">
           <h2 className="font-heading-md text-normal border-top padding-top-2">

--- a/src/components/MVP/ContentListItem/ContentListItem.stories.tsx
+++ b/src/components/MVP/ContentListItem/ContentListItem.stories.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import ContentListGroup from '../ContentListGroup/ContentListGroup'
+import ContentListItem from './ContentListItem'
+
+export default {
+  title: 'Components/Content List',
+  component: ContentListItem,
+  decorators: [
+    (Story) => (
+      <ContentListGroup heading="List Title">
+        <Story />
+      </ContentListGroup>
+    ),
+  ],
+} as Meta
+
+export const DefaultContentList = () => (
+  <ContentListItem heading="milConnect" path="/mil-connect">
+    Check your health insurance coverage. Schedule a CAC appointment or update
+    your account info.
+  </ContentListItem>
+)

--- a/src/components/MVP/ContentListItem/ContentListItem.test.tsx
+++ b/src/components/MVP/ContentListItem/ContentListItem.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ContentListGroup from '../ContentListGroup/ContentListGroup'
+import ContentListItem from './ContentListItem'
+
+describe('Content List Item component', () => {
+  beforeEach(() => {
+    render(
+      <ContentListGroup>
+        <ContentListItem heading="Item Title" path="/about">
+          Lorem ipsum
+        </ContentListItem>
+      </ContentListGroup>
+    )
+  })
+
+  it('renders the h3', () => {
+    expect(
+      screen.getByRole('heading', { name: 'Item Title' })
+    ).toBeInTheDocument()
+  })
+
+  it('renders the path', () => {
+    const link = screen.getByRole('link')
+
+    expect(link).toBeInstanceOf(HTMLAnchorElement)
+    expect(link).toHaveAttribute('href', '/about')
+  })
+
+  it('renders the children', () => {
+    expect(screen.getByText('Lorem ipsum')).toBeInstanceOf(HTMLParagraphElement)
+  })
+})

--- a/src/components/MVP/ContentListItem/ContentListItem.tsx
+++ b/src/components/MVP/ContentListItem/ContentListItem.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+interface ContentListItemProps {
+  children: React.ReactNode
+  heading: string
+  className?: string
+  path: string
+}
+
+const ContentListItem = ({
+  children,
+  heading,
+  path,
+}: ContentListItemProps): React.ReactElement => {
+  return (
+    <a href={path} className="section-links__item grid-row">
+      <div className="tablet:grid-col-4">
+        <h3>{heading}</h3>
+      </div>
+      <div className="tablet:grid-col-8">
+        <p>{children}</p>
+      </div>
+    </a>
+  )
+}
+
+export default ContentListItem


### PR DESCRIPTION
## Description 


WIP / not ready for review

This PR splits out the Content List as two components: Item and Group. For use on the home page rebuild.

* Adds `ContentListGroup` component and tests
* Adds `ContentListItem` component and tests

Fixes (part of) #16 

## Review Notes
`yarn storybook` to view the component group with one item