### PR TITLE
chore: Add Barry as a default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything
-* @suzubara @abbyoung
+* @suzubara @abbyoung @esacteksab
 
 # Github settings
 .github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth


### PR DESCRIPTION
## Description 

Adding @esacteksab as a default codeowner since having only two owners prohibits us from merging code changes if one is out.

Fixes #53 