### PR TITLE
ci: Updating dependabot. No package.json in /cypress and we don't want Node 16.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,8 @@ updates:
   schedule:
     interval: daily
     time: "11:00"
-  open-pull-requests-limit: 10
-  labels:
-  - 'type: dependencies'
-- package-ecosystem: npm
-  directory: "/cypress"
-  schedule:
-    interval: daily
-    time: "11:00"
+  ignore:
+    - dependency-name: "14-alpine"
   open-pull-requests-limit: 10
   labels:
   - 'type: dependencies'


### PR DESCRIPTION


## Description 

No `package.json` in `/cypress` directory. We don't want to update to Node 16. This should ignore that update.

Fixes #69 

