### PR TITLE
ci: Allow dependabot to manage all version updates, but auto-merge will only automate minor and patch versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,6 @@ updates:
   ignore:
       # We don't want to update uswds. This update will be handled manually as needed.
     - dependency-name: "uswds"
-      # We don't want packages to update between major versions. Patch and minor only. Hopefully ensuring no breaking changes.
-    - dependency-name: "*"
-      update-types: ["version-update:semver-major"]
   open-pull-requests-limit: 10
   labels:
   - 'type: dependencies'

--- a/.github/workflows/merge-me.yml
+++ b/.github/workflows/merge-me.yml
@@ -1,0 +1,35 @@
+name: Merge me!
+
+on:
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      # List all required workflow names here.
+      - 'Node CI'
+      - 'Cypress E2E tests'
+
+jobs:
+  merge-me:
+    name: Merge me!
+    runs-on: ubuntu-latest
+    steps:
+      - # It is often a desired behavior to merge only when a workflow execution
+        # succeeds. This can be changed as needed.
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        name: Merge me!
+        uses: ridedott/merge-me-action@v2
+        with:
+          # Depending on branch protection rules, a  manually populated
+          # `GITHUB_TOKEN_WORKAROUND` secret with permissions to push to
+          # a protected branch must be used. This secret can have an arbitrary
+          # name, as an example, this repository uses `DOTTBOTT_TOKEN`.
+          #
+          # When using a custom token, it is recommended to leave the following
+          # comment for other developers to be aware of the reasoning behind it:
+          #
+          # This must be used as GitHub Actions token does not support pushing
+          # to protected branches.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLE_GITHUB_API_PREVIEW: true
+          PRESET: DEPENDABOT_MINOR

--- a/.github/workflows/merge-me.yml
+++ b/.github/workflows/merge-me.yml
@@ -1,4 +1,4 @@
-name: Merge me!
+name: Automerge Dependabot!
 
 on:
   workflow_run:


### PR DESCRIPTION
## Description 

We decided to let Dependabot manage all version updates, even major. But we're configuring `auto-merge` to only manage minor and patch updates. Major updates will still be done manually.

Like the others, this needs to land in `main` to test.

Fixes #111 
