### PR TITLE
ci: Test Storybook builds during CI

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run Jest tests
         run: yarn test --coverage
+
+      - name: Build Storybook
+        run: yarn storybook --ci

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -41,4 +41,4 @@ jobs:
         run: yarn test --coverage
 
       - name: Build Storybook
-        run: yarn storybook --ci
+        run: yarn storybook --ci --smoke-test

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules/
 .next
 out/
 
+# Storybook build output
+storybook-static
+
 # Copied by yarn postinstall
 public/vendor/fonts
 public/vendor/img

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     'storybook-css-modules-preset',
+    'storybook-addon-next-router',
   ],
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,4 @@
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 import * as NextImage from 'next/image'
 import '../src/styles/index.scss'
 // Storybook and next/image component do not play nice together
@@ -15,5 +16,8 @@ export const parameters = {
       color: /(background|color)$/i,
       date: /Date$/,
     },
+  },
+  nextRouter: {
+    Provider: RouterContext.Provider,
   },
 }

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
     "lint-staged": "^11.1.2",
     "prettier": "2.3.2",
     "sass": "^1.37.5",
-    "sass-loader": "^12.1.0",
+    "sass-loader": "^10.0.0",
     "serve": "^12.0.0",
     "standard-version": "^9.3.1",
-    "storybook-addon-next-router": "^2.0.4",
+    "storybook-addon-next-router": "^3.0.7",
     "storybook-css-modules-preset": "^1.1.1",
     "style-loader": "2.0.0",
     "typescript": "4.3.5"

--- a/src/components/MVP/Header/Header.stories.tsx
+++ b/src/components/MVP/Header/Header.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
-import { withNextRouter } from 'storybook-addon-next-router'
 
 import Header from './Header'
 import styles from './Header.module.scss'
@@ -9,7 +8,6 @@ export default {
   title: 'Components/Header',
   component: Header,
   decorators: [
-    withNextRouter,
     (Story) => (
       <div className={styles.navContainer}>
         <Story />

--- a/yarn.lock
+++ b/yarn.lock
@@ -11691,13 +11691,16 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass-loader@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.1.0.tgz#b73324622231009da6fba61ab76013256380d201"
-  integrity sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==
+sass-loader@^10.0.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.0.tgz#3d64c1590f911013b3fa48a0b22a83d5e1494716"
+  integrity sha512-kUceLzC1gIHz0zNJPpqRsJyisWatGYNFRmv2CKZK2/ngMJgLqxTbXwe/hJ85luyvZkgqU3VlJ33UVF2T/0g6mw==
   dependencies:
     klona "^2.0.4"
+    loader-utils "^2.0.0"
     neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
 
 sass@^1.37.5:
   version "1.37.5"
@@ -12245,10 +12248,10 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.12.0.tgz#e1f1b7e1a59b6083b2596a8d067f6ee88fd4d3cf"
   integrity sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==
 
-storybook-addon-next-router@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-2.0.4.tgz#205a79b90ddb7a04b3da0ba2b613cde66790b68e"
-  integrity sha512-PAlAVA2joJC36r2uRU7pL5tNPqcOlcgJNuWyyiPAG6f/sptBK4EdOKUUdU0X9NBVV6BCkiwbLH/kkPmWYRxiFw==
+storybook-addon-next-router@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-3.0.7.tgz#38bb9f76a3f93560e3e374d7c8f7702021fa6ab5"
+  integrity sha512-D8cRPG5RwqVceHdaSeicaoJywKfwzdJHuwASLBaFdIfnMUAlCPmXjaYTGs3o5prKP2Mpdi5rpLCJMIaMBCdBeQ==
 
 storybook-addon-outline@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
## Description 

While working on another issue, I noticed that `yarn storybook` was breaking for a couple of reasons. This PR both:
*  Fixes the Storybook build (by downgrading certain packages that SB is not compatible with yet) and updating the usage of `storybook-addon-next-router`
* Adds a Storybook build to our existing CI so that in the future, changes that break SB will be caught before being merged

This PR does not persist the Storybook output anywhere, but that would be somewhat trivial to do in the future if we want (for example to [Github pages](https://github.com/storybookjs/storybook-deployer))

Fixes #147 

## Review Notes

If you look at the [Node CI actions for this branch](https://github.com/USSF-ORBIT/ussf-portal-client/actions/workflows/node-ci.yml?query=branch%3A147-storybook-ci) you can see the following:
- This run failed because of the Storybook errors: https://github.com/USSF-ORBIT/ussf-portal-client/runs/3372189706?check_suite_focus=true
- This run passed because the Storybook errors were fixed: https://github.com/USSF-ORBIT/ussf-portal-client/runs/3372363722?check_suite_focus=true