### PR TITLE
dev: Bookmark component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,9 @@
 import { RouterContext } from 'next/dist/shared/lib/router-context'
 import * as NextImage from 'next/image'
+
+import '../src/initIcons'
 import '../src/styles/index.scss'
+
 // Storybook and next/image component do not play nice together
 // This enables us to use the <Image/> component and still view in Storybook
 const OriginalNextImage = NextImage.default

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -6,6 +6,8 @@ import '@testing-library/jest-dom'
 import * as NextImage from 'next/image'
 import { toHaveNoViolations } from 'jest-axe'
 
+import './src/initIcons'
+
 // There are some open issues with NextImage in Jest:
 // https://github.com/vercel/next.js/issues/26749
 // https://github.com/vercel/next.js/issues/26606

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -4,6 +4,8 @@
 .bookmark {
   border: 1px solid color('base-light');
   border-radius: 5px;
+  box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
+
   display: flex;
 
   > a {

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -9,6 +9,13 @@
   > a {
     flex-grow: 1;
     padding: units('105') units(2);
+
+    /*
+    // if we want truncated text
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    */
   }
 }
 

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -1,0 +1,12 @@
+@import 'styles/uswdsDependencies';
+
+.bookmark {
+  border: 1px solid color('base-light');
+  border-radius: 5px;
+  display: flex;
+
+  > a {
+    flex-grow: 1;
+    padding: units('105') units(2);
+  }
+}

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -1,4 +1,5 @@
 @import 'styles/uswdsDependencies';
+@import 'styles/deps';
 
 .bookmark {
   border: 1px solid color('base-light');
@@ -9,4 +10,9 @@
     flex-grow: 1;
     padding: units('105') units(2);
   }
+}
+
+.delete {
+  @extend %button-reset;
+  padding: 0 units('105');
 }

--- a/src/components/Bookmark/Bookmark.stories.tsx
+++ b/src/components/Bookmark/Bookmark.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import Bookmark from './Bookmark'
+
+export default {
+  title: 'Components/Bookmark',
+  component: Bookmark,
+} as Meta
+
+export const ExampleBookmark = () => <Bookmark href="#">Example</Bookmark>

--- a/src/components/Bookmark/Bookmark.stories.tsx
+++ b/src/components/Bookmark/Bookmark.stories.tsx
@@ -2,9 +2,29 @@ import React from 'react'
 import { Meta } from '@storybook/react'
 import Bookmark from './Bookmark'
 
+type StorybookArgTypes = {
+  onDelete: () => void
+}
+
 export default {
   title: 'Components/Bookmark',
   component: Bookmark,
+  argTypes: { onDelete: { action: 'Deleted' } },
 } as Meta
 
 export const ExampleBookmark = () => <Bookmark href="#">Example</Bookmark>
+
+export const WithLongText = () => (
+  <Bookmark href="#">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+    quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+    consequat.
+  </Bookmark>
+)
+
+export const WithDeleteHandler = (argTypes: StorybookArgTypes) => (
+  <Bookmark href="#" onDelete={argTypes.onDelete}>
+    Delete Me
+  </Bookmark>
+)

--- a/src/components/Bookmark/Bookmark.test.tsx
+++ b/src/components/Bookmark/Bookmark.test.tsx
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
 import React from 'react'
 import Bookmark from './Bookmark'
 
@@ -17,5 +19,35 @@ describe('Bookmark component', () => {
     expect(link).toHaveAttribute('href', '/home')
     expect(link).toHaveTextContent('Home')
     expect(link).toBeInstanceOf(HTMLAnchorElement)
+  })
+
+  it('renders a delete button if a handler is provided', () => {
+    const mockOnDelete = jest.fn()
+
+    render(
+      <Bookmark href="/home" onDelete={mockOnDelete}>
+        Home
+      </Bookmark>
+    )
+
+    const button = screen.getByRole('button')
+    userEvent.click(button)
+    expect(mockOnDelete).toHaveBeenCalled()
+  })
+
+  it('has no a11y violations', async () => {
+    // Bug with NextJS Link + axe :(
+    // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
+    await act(async () => {
+      const mockOnDelete = jest.fn()
+
+      const { container } = render(
+        <Bookmark onDelete={mockOnDelete} href="/home">
+          Home
+        </Bookmark>
+      )
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
   })
 })

--- a/src/components/Bookmark/Bookmark.test.tsx
+++ b/src/components/Bookmark/Bookmark.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import Bookmark from './Bookmark'
+
+describe('Bookmark component', () => {
+  it('renders an anchor link', () => {
+    render(<Bookmark href="/home">Home</Bookmark>)
+
+    const link = screen.getByRole('link', {
+      name: 'Home',
+    })
+
+    expect(link).toHaveAttribute('href', '/home')
+    expect(link).toHaveTextContent('Home')
+    expect(link).toBeInstanceOf(HTMLAnchorElement)
+  })
+})

--- a/src/components/Bookmark/Bookmark.tsx
+++ b/src/components/Bookmark/Bookmark.tsx
@@ -1,13 +1,26 @@
 import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import styles from './Bookmark.module.scss'
 import LinkTo, { PropTypes as LinkToProps } from 'components/util/LinkTo/LinkTo'
 
-type PropTypes = LinkToProps
+type PropTypes = LinkToProps & {
+  onDelete?: () => void
+}
 
-const Bookmark = ({ children, ...linkProps }: PropTypes) => {
+const Bookmark = ({ children, onDelete, ...linkProps }: PropTypes) => {
   return (
     <div className={styles.bookmark}>
       <LinkTo {...linkProps}>{children}</LinkTo>
+
+      {onDelete && (
+        <button
+          type="button"
+          onClick={onDelete}
+          className={styles.delete}
+          aria-label="Remove this bookmark">
+          <FontAwesomeIcon icon="times" />
+        </button>
+      )}
     </div>
   )
 }

--- a/src/components/Bookmark/Bookmark.tsx
+++ b/src/components/Bookmark/Bookmark.tsx
@@ -1,16 +1,26 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import classnames from 'classnames'
 import styles from './Bookmark.module.scss'
 import LinkTo, { PropTypes as LinkToProps } from 'components/util/LinkTo/LinkTo'
 
 type PropTypes = LinkToProps & {
-  onDelete?: () => void
+  onDelete?: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-const Bookmark = ({ children, onDelete, ...linkProps }: PropTypes) => {
+const Bookmark = ({
+  children,
+  className,
+  onDelete,
+  ...linkProps
+}: PropTypes) => {
+  const linkClasses = classnames('usa-link', className)
+
   return (
     <div className={styles.bookmark}>
-      <LinkTo {...linkProps}>{children}</LinkTo>
+      <LinkTo {...linkProps} className={linkClasses}>
+        {children}
+      </LinkTo>
 
       {onDelete && (
         <button

--- a/src/components/Bookmark/Bookmark.tsx
+++ b/src/components/Bookmark/Bookmark.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import styles from './Bookmark.module.scss'
+import LinkTo, { PropTypes as LinkToProps } from 'components/util/LinkTo/LinkTo'
+
+type PropTypes = LinkToProps
+
+const Bookmark = ({ children, ...linkProps }: PropTypes) => {
+  return (
+    <div className={styles.bookmark}>
+      <LinkTo {...linkProps}>{children}</LinkTo>
+    </div>
+  )
+}
+
+export default Bookmark

--- a/src/initIcons.ts
+++ b/src/initIcons.ts
@@ -1,0 +1,4 @@
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faTimes } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faTimes)

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,13 +1,20 @@
-import 'styles/index.scss'
-import '../../public/vendor/fontawesome-pro-5.15.1-web/css/all.min.css'
+import type { NextPage } from 'next'
 import Head from 'next/head'
 import type { AppProps } from 'next/app'
 import { useRouter } from 'next/router'
 import type { ReactNode } from 'react'
-import { config, dom } from '@fortawesome/fontawesome-svg-core'
-import type { NextPage } from 'next'
+import { config } from '@fortawesome/fontawesome-svg-core'
+
+import '@fortawesome/fontawesome-svg-core/styles.css'
+import 'styles/index.scss'
+import '../../public/vendor/fontawesome-pro-5.15.1-web/css/all.min.css'
+
+import 'initIcons'
 import DefaultLayout from 'layout/MVP/DefaultLayout/DefaultLayout'
 import { BetaContextProvider } from 'stores/betaContext'
+
+config.autoAddCss = false
+
 type Page<P = Record<string, never>> = NextPage<P> & {
   getLayout?: (page: ReactNode) => ReactNode
 }
@@ -19,7 +26,6 @@ type Props = AppProps & {
 const USSFPortalApp = ({ Component, pageProps }: Props) => {
   const canonicalUrl = process.env.NEXT_PUBLIC_SITE_URL || ''
   const { asPath } = useRouter()
-  config.autoAddCss = false
 
   const getLayout =
     Component.getLayout ||
@@ -62,9 +68,6 @@ const USSFPortalApp = ({ Component, pageProps }: Props) => {
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#ffffff" />
-        {/* https://github.com/FortAwesome/react-fontawesome/issues/284 */}
-        {/* Fix Next.js's rendering of font awesome css */}
-        <style>${dom.css()}</style>
       </Head>
       {getLayout(<Component {...pageProps} />)}
     </BetaContextProvider>

--- a/src/styles/_deps.scss
+++ b/src/styles/_deps.scss
@@ -1,0 +1,20 @@
+%button-reset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  width: auto;
+  overflow: visible;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  line-height: normal;
+  -webkit-font-smoothing: inherit;
+  -moz-osx-font-smoothing: inherit;
+  -webkit-appearance: none;
+  cursor: pointer;
+
+  &::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+}


### PR DESCRIPTION
## Description 

Adds a Bookmark component that wraps the existing `LinkTo` component with some styling and an optional delete button.

Bookmark prop types:
```
type PropTypes = LinkToProps & {
  onDelete?: (event: React.MouseEvent<HTMLButtonElement>) => void
}
```

API:
```
<Bookmark href="#">Example</Bookmark>

<Bookmark href="#" onDelete={handleDelete}>Delete Me</Bookmark>
```

Fixes #192 

## Review Notes

This PR just adds the new component in Storybook, so to test pull down this branch and run:
```
yarn storybook
```

You should see Bookmark under the Components section in the navigation, and be able to click through the various examples.

![image](https://user-images.githubusercontent.com/2723066/132045366-62c7aab7-852f-46a3-a0d4-97b083f6f067.png)

One design question for @MKDale @malworks -- I added an example with a long text string, which currently just wraps the text, but another option is to truncate with an ellipsis:

![image](https://user-images.githubusercontent.com/2723066/132045189-292e1417-f35d-46c7-ac71-f5fbdcca7a35.png)

Do you have a preference? I'm imagining a scenario where users add a link without giving it a title, and the display text defaults to the URL (which can be quite long)

## Screenshots

![image](https://user-images.githubusercontent.com/2723066/132044588-aed40ad6-bc70-4ea8-815a-d1564172ec25.png)

![image](https://user-images.githubusercontent.com/2723066/132044616-220bb939-963c-49d5-b9e0-6de8595a16f3.png)

![image](https://user-images.githubusercontent.com/2723066/132044638-79fdf562-2549-496b-bb38-818dc1dcc8e5.png)
