### PR TITLE
dev: Placeholder static data component

### DIFF
--- a/src/components/PersonalData/PersonalData.module.scss
+++ b/src/components/PersonalData/PersonalData.module.scss
@@ -5,10 +5,6 @@
     @include u-font-size('heading', 14);
     margin-bottom: units(2.5);
   }
-  dl {
-    @include add-list-reset;
-    // display: flex;
-  }
   dt {
     @include u-line-height('heading', 3);
     font-weight: 700;

--- a/src/components/PersonalData/PersonalData.module.scss
+++ b/src/components/PersonalData/PersonalData.module.scss
@@ -1,0 +1,21 @@
+@import 'styles/uswdsDependencies';
+
+.personalData {
+  h2 {
+    @include u-font-size('heading', 14);
+    margin-bottom: units(2.5);
+  }
+  dl {
+    @include add-list-reset;
+    // display: flex;
+  }
+  dt {
+    @include u-line-height('heading', 3);
+    font-weight: 700;
+  }
+  dd {
+    @include u-line-height('body', 4);
+    margin-inline-start: 0;
+    margin-bottom: units(2);
+  }
+}

--- a/src/components/PersonalData/PersonalData.stories.tsx
+++ b/src/components/PersonalData/PersonalData.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
-import { CardGroup } from '@trussworks/react-uswds'
 import PersonalData from './PersonalData'
 
 export default {

--- a/src/components/PersonalData/PersonalData.stories.tsx
+++ b/src/components/PersonalData/PersonalData.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import { CardGroup } from '@trussworks/react-uswds'
+import PersonalData from './PersonalData'
+
+export default {
+  title: 'Beta/Components/PersonalData',
+} as Meta
+
+export const PersonalDataPlaceholder = () => <PersonalData />

--- a/src/components/PersonalData/PersonalData.test.tsx
+++ b/src/components/PersonalData/PersonalData.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+import type { RenderResult } from '@testing-library/react'
+import React from 'react'
+import { axe } from 'jest-axe'
+import PersonalData from './PersonalData'
+
+describe('Personal Data Placeholder', () => {
+  let html: RenderResult
+  beforeEach(() => {
+    html = render(<PersonalData />)
+  })
+
+  it('renders the Greeting', () => {
+    const greeting = screen.getByRole('heading', { level: 2 })
+    expect(greeting).toHaveTextContent('Welcome, Sgt Snuffy')
+  })
+
+  it('renders the list of key/value pairs', () => {
+    expect(screen.getAllByRole('definition')).toHaveLength(4)
+  })
+
+  it('has no a11y violations', async () => {
+    expect(await axe(html.container)).toHaveNoViolations()
+  })
+})

--- a/src/components/PersonalData/PersonalData.tsx
+++ b/src/components/PersonalData/PersonalData.tsx
@@ -1,34 +1,31 @@
 import React from 'react'
-import { Meta } from '@storybook/react'
 import { GridContainer, Grid } from '@trussworks/react-uswds'
-import styles from './PersonalData'
+import styles from './PersonalData.module.scss'
 
 const PersonalData = () => {
-  const testContent = 'test content'
   return (
-    <>
-      <h2>Welcome, Sgt Snuffy</h2>
+    <div className={styles.personalData}>
       <GridContainer>
-        <Grid row gap={2}>
-          <Grid col={4}>
-            <dl>
-              <dt>Next PT Test:</dt>
-              <dd>In 67 days on 12 Dec 2021</dd>
-              <dt>Next Immunization:</dt>
-              <dd>Influenza due on 04 July 2021</dd>
-            </dl>
+        <h2>Welcome, Sgt Snuffy</h2>
+
+        <dl className="grid-row">
+          <Grid tablet={{ col: true }}>
+            <dt>Next PT Test:</dt>
+            <dd>In 67 days on 12 Dec 2021</dd>
+
+            <dt>Next Immunization:</dt>
+            <dd>Influenza due on 04 July 2021</dd>
           </Grid>
-          <Grid col={4}>
-            <dl>
-              <dt>Next EPR:</dt>
-              <dd>In 245 days on 12 July 2022</dd>
-              <dt>Current Leave Balance:</dt>
-              <dd>20.5 Days</dd>
-            </dl>
+          <Grid tablet={{ col: true }}>
+            <dt>Next EPR:</dt>
+            <dd>In 245 days on 12 July 2022</dd>
+
+            <dt>Current Leave Balance:</dt>
+            <dd>20.5 Days</dd>
           </Grid>
-        </Grid>
+        </dl>
       </GridContainer>
-    </>
+    </div>
   )
 }
 

--- a/src/components/PersonalData/PersonalData.tsx
+++ b/src/components/PersonalData/PersonalData.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import { GridContainer, Grid } from '@trussworks/react-uswds'
+import styles from './PersonalData'
+
+const PersonalData = () => {
+  const testContent = 'test content'
+  return (
+    <>
+      <h2>Welcome, Sgt Snuffy</h2>
+      <GridContainer>
+        <Grid row gap={2}>
+          <Grid col={4}>
+            <dl>
+              <dt>Next PT Test:</dt>
+              <dd>In 67 days on 12 Dec 2021</dd>
+              <dt>Next Immunization:</dt>
+              <dd>Influenza due on 04 July 2021</dd>
+            </dl>
+          </Grid>
+          <Grid col={4}>
+            <dl>
+              <dt>Next EPR:</dt>
+              <dd>In 245 days on 12 July 2022</dd>
+              <dt>Current Leave Balance:</dt>
+              <dd>20.5 Days</dd>
+            </dl>
+          </Grid>
+        </Grid>
+      </GridContainer>
+    </>
+  )
+}
+
+export default PersonalData


### PR DESCRIPTION
## Description 

This PR adds a placeholder component for the greeting/personal data as shown below.

* Static component to use for beta testing more complete pages
* Standard uswds styling
* Adds tests

![image](https://user-images.githubusercontent.com/6007259/132075327-b9e566ef-97e0-4c2b-b948-05b427054501.png)


Fixes #197 

## Review Notes

You can view the component in Storybook here: https://197-static-personal-data-component--ussf-storybook.netlify.app/?path=/story/beta-components-personaldata--personal-data-placeholder
