### PR TITLE
fix: Fix link color on home page

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,3 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,10 +105,14 @@ const Home = () => {
                 </h2>
                 <ul className="usa-list usa-list--unstyled margin-top-2 font-body-xs">
                   <li>
-                    <a href="https://mypay.dfas.mil/">myPay</a>
+                    <a className="usa-link" href="https://mypay.dfas.mil/">
+                      myPay
+                    </a>
                   </li>
                   <li className="margin-top-05">
-                    <a href="https://dtsproweb.defensetravel.osd.mil/dts-app/pubsite/all/view/">
+                    <a
+                      className="usa-link"
+                      href="https://dtsproweb.defensetravel.osd.mil/dts-app/pubsite/all/view/">
                       DTS
                     </a>
                   </li>


### PR DESCRIPTION
## Description 

This adds the `usa-link` class to the Quick Links on the home page so they have the correct link color.

Fixes #224 

## Screenshots:

Bug:

![image](https://user-images.githubusercontent.com/2723066/132904937-b8330f9d-beb5-4a7f-b935-06b985457735.png)

Fixed:

![image](https://user-images.githubusercontent.com/2723066/132904110-763ba140-f5b7-4e11-b286-910453c11831.png)

