### PR TITLE
fix: Fix link color on home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.0.1](https://github.com/USSF-ORBIT/ussf-portal-client/compare/1.0.0...1.0.1) (2021-09-10)
+
+
+### Bug Fixes
+
+* Fix link color on home page ([#225](https://github.com/USSF-ORBIT/ussf-portal-client/issues/225)) ([699c9d9](https://github.com/USSF-ORBIT/ussf-portal-client/commit/699c9d90747ffc5e473a96a81f1a478343537790))
+
 ## 1.0.0 (2021-08-19)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussf-portal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "engines": {
     "node": "14.17.6"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,10 +105,14 @@ const Home = () => {
                 </h2>
                 <ul className="usa-list usa-list--unstyled margin-top-2 font-body-xs">
                   <li>
-                    <a href="https://mypay.dfas.mil/">myPay</a>
+                    <a className="usa-link" href="https://mypay.dfas.mil/">
+                      myPay
+                    </a>
                   </li>
                   <li className="margin-top-05">
-                    <a href="https://dtsproweb.defensetravel.osd.mil/dts-app/pubsite/all/view/">
+                    <a
+                      className="usa-link"
+                      href="https://dtsproweb.defensetravel.osd.mil/dts-app/pubsite/all/view/">
                       DTS
                     </a>
                   </li>


### PR DESCRIPTION
## Description 

Updates `main` with the [1.0.1 release](https://github.com/USSF-ORBIT/ussf-portal-client/releases/tag/1.0.1).

Fixes #224 