### PR TITLE
feat: Add custom link to collection

### DIFF
--- a/cypress/integration/sites-and-applications.spec.js
+++ b/cypress/integration/sites-and-applications.spec.js
@@ -21,7 +21,7 @@ describe('Sites and Applications', () => {
     cy.contains('Application name').should('not.exist')
   })
 
-  it('can edit links on the My Space page', () => {
+  it('can hide links from an existing collection', () => {
     cy.contains('My Space')
 
     cy.contains('Example Collection')
@@ -45,6 +45,36 @@ describe('Sites and Applications', () => {
           .click()
         cy.contains('Webmail').should('not.exist')
         cy.findAllByRole('listitem').should('have.length', 4)
+      })
+  })
+
+  it('can add custom links to an existing collection', () => {
+    cy.contains('Example Collection')
+      .parent()
+      .within(() => {
+        // Add a link
+        cy.findByRole('button', { name: '+ Add link' }).click()
+
+        cy.findByLabelText('URL')
+          .then(($el) => $el[0].checkValidity())
+          .should('be.false')
+
+        cy.findByLabelText('URL')
+          .type('not a URL')
+          .then(($el) => $el[0].checkValidity())
+          .should('be.false')
+
+        cy.findByLabelText('URL')
+          .clear()
+          .type('http://www.example.com')
+          .then(($el) => $el[0].checkValidity())
+          .should('be.true')
+
+        cy.findByRole('button', { name: 'Add site' }).click()
+
+        cy.findByRole('link', {
+          name: 'http://www.example.com (opens in a new window)',
+        }).should('exist')
       })
   })
 })

--- a/src/apolloClient.tsx
+++ b/src/apolloClient.tsx
@@ -1,9 +1,11 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client'
 import { v4 } from 'uuid'
+
+import { typeDefs } from './schema'
+
 import type { Collection } from 'types'
 import { GET_COLLECTIONS } from 'operations/queries/getCollections'
 import { localResolvers } from 'operations/resolvers'
-import { typeDefs } from './schema'
 
 // Initialize cache
 export const initCache = () => {

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -12,12 +12,10 @@
     flex-grow: 1;
     padding: units('105') units(2);
 
-    /*
-    // if we want truncated text
+    // truncated text
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    */
   }
 }
 

--- a/src/components/Collection/Collection.module.scss
+++ b/src/components/Collection/Collection.module.scss
@@ -25,6 +25,7 @@
 
       > * {
         flex: auto;
+        width: 100%;
       }
     }
 

--- a/src/components/Collection/Collection.test.tsx
+++ b/src/components/Collection/Collection.test.tsx
@@ -66,4 +66,18 @@ describe('Collection component', () => {
       expect(await axe(html.container)).toHaveNoViolations()
     })
   })
+
+  it('can render a footer node', async () => {
+    const testFooter = <p>Collection footer</p>
+
+    html = render(
+      <Collection title="Example collection" footer={testFooter}>
+        <Bookmark key="link1" href="#">
+          Link 1
+        </Bookmark>
+      </Collection>
+    )
+
+    expect(screen.getByText('Collection footer')).toBeInTheDocument()
+  })
 })

--- a/src/components/Collection/Collection.tsx
+++ b/src/components/Collection/Collection.tsx
@@ -5,9 +5,10 @@ import styles from './Collection.module.scss'
 type PropTypes = {
   title: React.ReactNode
   children: React.ReactNode | React.ReactNode[]
+  footer?: React.ReactNode
 }
 
-const Collection = ({ title, children }: PropTypes) => {
+const Collection = ({ title, children, footer }: PropTypes) => {
   return (
     <div className={styles.collection}>
       <h3>{title}</h3>
@@ -18,6 +19,8 @@ const Collection = ({ title, children }: PropTypes) => {
           <li key={`bookmark_0`}>{children}</li>
         )}
       </ol>
+
+      {footer}
     </div>
   )
 }

--- a/src/components/CustomCollection/CustomCollection.module.scss
+++ b/src/components/CustomCollection/CustomCollection.module.scss
@@ -10,3 +10,8 @@
   @include u-padding('205' 4);
   @include u-margin-x(-2);
 }
+
+.addLink {
+  @include u-padding-x(2);
+  @include u-margin-top(2);
+}

--- a/src/components/CustomCollection/CustomCollection.stories.tsx
+++ b/src/components/CustomCollection/CustomCollection.stories.tsx
@@ -4,12 +4,16 @@ import CustomCollection from './CustomCollection'
 
 type StorybookArgTypes = {
   handleRemoveBookmark: () => void
+  handleAddBookmark: () => void
 }
 
 export default {
   title: 'Components/CustomCollection',
   component: CustomCollection,
-  argTypes: { handleRemoveBookmark: { action: 'Remove bookmark' } },
+  argTypes: {
+    handleRemoveBookmark: { action: 'Remove bookmark' },
+    handleAddBookmark: { action: 'Add bookmark' },
+  },
 } as Meta
 
 export const ExampleCustomCollection = (argTypes: StorybookArgTypes) => (
@@ -17,5 +21,6 @@ export const ExampleCustomCollection = (argTypes: StorybookArgTypes) => (
     title="Example collection"
     bookmarks={[{ id: 'link1', url: '#', label: 'Webmail' }]}
     handleRemoveBookmark={argTypes.handleRemoveBookmark}
+    handleAddBookmark={argTypes.handleAddBookmark}
   />
 )

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -6,7 +6,6 @@ import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { v4 } from 'uuid'
-import { MockedProvider } from '@apollo/client/testing'
 
 import CustomCollection, { RemovableBookmark } from './CustomCollection'
 
@@ -38,12 +37,11 @@ const exampleCollection = {
 describe('CustomCollection component', () => {
   it('renders the collection with delete buttons', () => {
     render(
-      <MockedProvider>
-        <CustomCollection
-          {...exampleCollection}
-          handleRemoveBookmark={jest.fn()}
-        />
-      </MockedProvider>
+      <CustomCollection
+        {...exampleCollection}
+        handleRemoveBookmark={jest.fn()}
+        handleAddBookmark={jest.fn()}
+      />
     )
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
@@ -59,6 +57,31 @@ describe('CustomCollection component', () => {
       screen.getAllByRole('button', { name: 'Remove this bookmark' })
     ).toHaveLength(exampleCollection.bookmarks.length)
   })
+
+  it('renders an Add Link toggleable form', () => {
+    const mockAddLink = jest.fn()
+    render(
+      <CustomCollection
+        {...exampleCollection}
+        handleRemoveBookmark={jest.fn()}
+        handleAddBookmark={mockAddLink}
+      />
+    )
+
+    const toggleFormButton = screen.getByRole('button', { name: '+ Add link' })
+    expect(toggleFormButton).toBeInTheDocument()
+
+    userEvent.click(toggleFormButton)
+    const urlInput = screen.getByLabelText('URL')
+    expect(urlInput).toBeInTheDocument()
+    userEvent.type(urlInput, 'example')
+    expect(urlInput).toBeInvalid()
+    userEvent.type(urlInput, 'http://www.example.com')
+    expect(urlInput).toBeValid()
+
+    userEvent.click(screen.getByRole('button', { name: 'Add site' }))
+    expect(mockAddLink).toHaveBeenCalled()
+  })
 })
 
 describe('RemovableBookmark component', () => {
@@ -70,9 +93,7 @@ describe('RemovableBookmark component', () => {
 
   it('renders a bookmark with a delete handler', () => {
     render(
-      <MockedProvider>
-        <RemovableBookmark bookmark={testBookmark} handleRemove={jest.fn()} />
-      </MockedProvider>
+      <RemovableBookmark bookmark={testBookmark} handleRemove={jest.fn()} />
     )
 
     expect(screen.getByRole('link')).toHaveTextContent(testBookmark.label)
@@ -87,12 +108,10 @@ describe('RemovableBookmark component', () => {
     const mockHandleRemove = jest.fn()
 
     render(
-      <MockedProvider>
-        <RemovableBookmark
-          bookmark={testBookmark}
-          handleRemove={mockHandleRemove}
-        />
-      </MockedProvider>
+      <RemovableBookmark
+        bookmark={testBookmark}
+        handleRemove={mockHandleRemove}
+      />
     )
 
     const deleteButton = screen.getByRole('button', {
@@ -126,12 +145,10 @@ describe('RemovableBookmark component', () => {
     const mockHandleRemove = jest.fn()
 
     render(
-      <MockedProvider>
-        <RemovableBookmark
-          bookmark={testBookmark}
-          handleRemove={mockHandleRemove}
-        />
-      </MockedProvider>
+      <RemovableBookmark
+        bookmark={testBookmark}
+        handleRemove={mockHandleRemove}
+      />
     )
 
     const deleteButton = screen.getByRole('button', {

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -102,6 +102,22 @@ describe('RemovableBookmark component', () => {
     ).toBeInTheDocument()
   })
 
+  it('renders the bookmark URL if there is no label', () => {
+    const testBookmarkNoLabel = {
+      id: v4(),
+      url: 'https://example.com',
+    }
+
+    render(
+      <RemovableBookmark
+        bookmark={testBookmarkNoLabel}
+        handleRemove={jest.fn()}
+      />
+    )
+
+    expect(screen.getByRole('link')).toHaveTextContent(testBookmarkNoLabel.url)
+  })
+
   it('allows the delete handler to be undone', async () => {
     jest.useFakeTimers()
 

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -74,6 +74,8 @@ describe('CustomCollection component', () => {
     userEvent.click(toggleFormButton)
     const urlInput = screen.getByLabelText('URL')
     expect(urlInput).toBeInTheDocument()
+    expect(urlInput).toBeInvalid()
+
     userEvent.type(urlInput, 'example')
     expect(urlInput).toBeInvalid()
     userEvent.type(urlInput, 'http://www.example.com')

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -12,7 +12,7 @@ type PropTypes = {
   title: string
   bookmarks: BookmarkType[]
   handleRemoveBookmark: (id: string) => void
-  handleAddBookmark: (url: string) => void
+  handleAddBookmark: (url: string, label?: string) => void
 }
 
 const UNDO_TIMEOUT = 3000 // 3 seconds
@@ -54,7 +54,7 @@ export const RemovableBookmark = ({
     </button>
   ) : (
     <Bookmark href={url} onDelete={handleDeleteBookmark}>
-      {label}
+      {label || url}
     </Bookmark>
   )
 }
@@ -71,8 +71,9 @@ const CustomCollection = ({
 
   const handleSubmitAdd = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    // console.log('submit', event.target)
-    handleAddBookmark('test')
+    const data = new FormData(event.currentTarget)
+    const url = `${data.get('bookmarkUrl')}`
+    handleAddBookmark(url)
   }
 
   const addLinkForm = (

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -74,6 +74,7 @@ const CustomCollection = ({
     const data = new FormData(event.currentTarget)
     const url = `${data.get('bookmarkUrl')}`
     handleAddBookmark(url)
+    setIsAdding(false)
   }
 
   const addLinkForm = (
@@ -88,6 +89,7 @@ const CustomCollection = ({
             id="bookmarkUrl"
             name="bookmarkUrl"
             placeholder="Type or paste link..."
+            required
           />
           <Button type="submit">Add site</Button>
         </Form>

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { Button, Form, Label, TextInput } from '@trussworks/react-uswds'
 
 import styles from './CustomCollection.module.scss'
 
@@ -11,6 +12,7 @@ type PropTypes = {
   title: string
   bookmarks: BookmarkType[]
   handleRemoveBookmark: (id: string) => void
+  handleAddBookmark: (url: string) => void
 }
 
 const UNDO_TIMEOUT = 3000 // 3 seconds
@@ -61,9 +63,43 @@ const CustomCollection = ({
   title,
   bookmarks,
   handleRemoveBookmark,
+  handleAddBookmark,
 }: PropTypes) => {
+  const [isAdding, setIsAdding] = useState<boolean>(false)
+
+  const handleShowAdding = () => setIsAdding(true)
+
+  const handleSubmitAdd = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    // console.log('submit', event.target)
+    handleAddBookmark('test')
+  }
+
+  const addLinkForm = (
+    <div className={styles.addLink}>
+      {isAdding ? (
+        <Form onSubmit={handleSubmitAdd}>
+          <Label htmlFor="bookmarkUrl" className="usa-sr-only">
+            URL
+          </Label>
+          <TextInput
+            type="url"
+            id="bookmarkUrl"
+            name="bookmarkUrl"
+            placeholder="Type or paste link..."
+          />
+          <Button type="submit">Add site</Button>
+        </Form>
+      ) : (
+        <Button type="button" outline onClick={handleShowAdding}>
+          + Add link
+        </Button>
+      )}
+    </div>
+  )
+
   return (
-    <Collection title={title}>
+    <Collection title={title} footer={addLinkForm}>
       {bookmarks.map((bookmark: BookmarkType) => (
         <RemovableBookmark
           key={`bookmark_${bookmark.id}`}

--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -4,10 +4,12 @@ import styles from './MySpace.module.scss'
 import CustomCollection from 'components/CustomCollection/CustomCollection'
 import { useCollectionsQuery } from 'operations/queries/getCollections'
 import { useRemoveBookmarkMutation } from 'operations/mutations/removeBookmark'
+import { useAddBookmarkMutation } from 'operations/mutations/addBookmark'
 
 const MySpace = () => {
   const { loading, error, data } = useCollectionsQuery()
   const [handleRemoveBookmark] = useRemoveBookmarkMutation()
+  const [handleAddBookmark] = useAddBookmarkMutation()
 
   if (loading) return <p>Loading...</p>
   if (error) return <p>Error</p>
@@ -31,6 +33,15 @@ const MySpace = () => {
                       variables: { id, collectionId: collection.id },
                     })
                   }
+                  handleAddBookmark={(url, label) => {
+                    handleAddBookmark({
+                      variables: {
+                        collectionId: collection.id,
+                        url,
+                        label,
+                      },
+                    })
+                  }}
                 />
               </Grid>
             ))}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -199,7 +199,7 @@ const Home = () => {
                     .
                   </p>
                   <LinkTo
-                    className="usa-button text-white text-no-underline"
+                    className="usa-button button-pill text-white text-no-underline"
                     href="/training-and-education/">
                     More in Training + Education
                   </LinkTo>

--- a/src/pages/login-notice.tsx
+++ b/src/pages/login-notice.tsx
@@ -79,7 +79,7 @@ const LoginNotice = () => {
                   </p>
                   <LinkTo
                     href="/login"
-                    className="usa-button usa-button--big text-white text-no-underline">
+                    className="usa-button button-pill usa-button--big text-white text-no-underline">
                     I agree
                   </LinkTo>
                 </div>

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -48,7 +48,7 @@ const Login = () => {
                   Insert your CAC / ECA to begin your login
                 </p>
                 <LinkTo
-                  className="usa-button usa-button--big text-white text-no-underline"
+                  className="usa-button button-pill usa-button--big text-white text-no-underline"
                   href="/">
                   Login
                 </LinkTo>

--- a/src/pages/training-and-education/force-multiplier-program.tsx
+++ b/src/pages/training-and-education/force-multiplier-program.tsx
@@ -14,7 +14,7 @@ const ForceMultiplierProgram = () => {
             The Digital University Force Multiplier Program
           </p>
           <LinkTo
-            className="usa-button usa-button--big external-link--alt text-white text-no-underline"
+            className="usa-button button-pill usa-button--big external-link--alt text-white text-no-underline"
             href="http://digitalu.udemy.com">
             Register
           </LinkTo>

--- a/src/styles/mvp/_buttons.scss
+++ b/src/styles/mvp/_buttons.scss
@@ -1,4 +1,4 @@
-.usa-button {
+.button-pill {
   background-color: color('blue-warm-60v');
   @include heading-small;
   @extend .radius-pill;

--- a/src/styles/mvp/_global.scss
+++ b/src/styles/mvp/_global.scss
@@ -50,8 +50,8 @@
   }
 }
 
-.usa-button,
-.usa-prose > a.usa-button {
+.button-pill,
+.usa-prose > a.button-pill {
   background-color: color('blue-warm-60v');
   color: color('white');
   text-decoration: none;


### PR DESCRIPTION
## Description 

This PR adds the "Add link" flow to the Custom Collection component, allowing users to add arbitrary links to existing collections.

In the interest of keeping PRs small, this does _not_ include the modal that asks a user to enter a custom label for their link. That feature is added in https://github.com/USSF-ORBIT/ussf-portal-client/pull/250

I'm considering this branch to be feature complete since a user is still able to add a link. The display text will just default to the URL.

Fixes #233 

## Review Notes

* Verify you can click "Add link" on an existing collection in My Space to add a new URL to the collection.
* The text input should validate that you have entered a complete & valid URL. Entering other text or no text at all should prevent you from submitting the link.
* Since the link is only added in the local cache, refreshing the page will reset any changes you've made.

![addLink](https://user-images.githubusercontent.com/2723066/135926196-13649a82-5c84-48af-9dd0-507fded8030e.gif)