### PR TITLE
feat: Add custom link modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@keystone-next/fields": "15.0.0",
     "@keystone-next/keystone": "25.0.1",
     "@next/bundle-analyzer": "11.1.2",
-    "@trussworks/react-uswds": "2.0.0",
+    "@trussworks/react-uswds": "https://github.com/trussworks/react-uswds#sr-1233-modal-component",
     "classnames": "2.3.1",
     "graphql": "^15.5.3",
     "next": "11.1.2",
@@ -42,7 +42,7 @@
     "react": "17.0.2",
     "react-cookie": "^4.1.1",
     "react-dom": "17.0.2",
-    "uswds": "2.10.3"
+    "uswds": "2.11.2"
   },
   "devDependencies": {
     "@babel/core": "7.15.5",

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -1,12 +1,19 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { Button, Form, Label, TextInput } from '@trussworks/react-uswds'
+import {
+  Button,
+  Form,
+  Label,
+  TextInput,
+  useModal,
+} from '@trussworks/react-uswds'
 
 import styles from './CustomCollection.module.scss'
 
 import Collection from 'components/Collection/Collection'
 import Bookmark from 'components/Bookmark/Bookmark'
 import type { Bookmark as BookmarkType } from 'types/index'
+import AddCustomLinkModal from 'components/modals/AddCustomLinkModal'
 
 type PropTypes = {
   title: string
@@ -66,14 +73,34 @@ const CustomCollection = ({
   handleAddBookmark,
 }: PropTypes) => {
   const [isAdding, setIsAdding] = useState<boolean>(false)
+  const urlInputValue = useRef<string>()
+  const { isOpen, openModal, closeModal } = useModal()
 
   const handleShowAdding = () => setIsAdding(true)
 
+  const handleCancel = () => {
+    setIsAdding(false)
+    closeModal()
+  }
+
   const handleSubmitAdd = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+
     const data = new FormData(event.currentTarget)
     const url = `${data.get('bookmarkUrl')}`
-    handleAddBookmark(url)
+    urlInputValue.current = url
+
+    openModal()
+  }
+
+  const handleSaveBookmark = (label: string) => {
+    if (urlInputValue.current) {
+      handleAddBookmark(urlInputValue.current, label)
+      setIsAdding(false)
+      closeModal()
+    } else {
+      // need a URL value
+    }
   }
 
   const addLinkForm = (
@@ -88,6 +115,12 @@ const CustomCollection = ({
             id="bookmarkUrl"
             name="bookmarkUrl"
             placeholder="Type or paste link..."
+            required
+          />
+          <AddCustomLinkModal
+            isOpen={isOpen}
+            onCancel={handleCancel}
+            onSave={handleSaveBookmark}
           />
           <Button type="submit">Add site</Button>
         </Form>

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -121,6 +121,7 @@ const CustomCollection = ({
             isOpen={isOpen}
             onCancel={handleCancel}
             onSave={handleSaveBookmark}
+            closeModal={closeModal}
           />
           <Button type="submit">Add site</Button>
         </Form>

--- a/src/components/modals/AddCustomLinkModal.tsx
+++ b/src/components/modals/AddCustomLinkModal.tsx
@@ -15,7 +15,7 @@ import ModalPortal from 'components/util/ModalPortal'
 type AddCustomLinkModalProps = {
   onSave: (label: string) => void
   onCancel: () => void
-} & ModalProps
+} & Omit<ModalProps, 'children' | 'id'>
 
 const AddCustomLinkModal = ({
   onSave,
@@ -34,11 +34,12 @@ const AddCustomLinkModal = ({
   return (
     <ModalPortal>
       <Modal
+        {...props}
         id={modalId}
         aria-labelledby={`${modalId}-heading`}
         aria-describedby={`${modalId}-description`}
         forceAction
-        {...props}>
+        modalRoot="#modal-root">
         <ModalHeading id={`${modalId}-heading`}>
           We don’t recognize that link
         </ModalHeading>

--- a/src/components/modals/AddCustomLinkModal.tsx
+++ b/src/components/modals/AddCustomLinkModal.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import {
+  Modal,
+  ModalProps,
+  ModalHeading,
+  Form,
+  ButtonGroup,
+  Button,
+  Label,
+  TextInput,
+} from '@trussworks/react-uswds'
+
+import ModalPortal from 'components/util/ModalPortal'
+
+type AddCustomLinkModalProps = {
+  onSave: (label: string) => void
+  onCancel: () => void
+} & ModalProps
+
+const AddCustomLinkModal = (props: AddCustomLinkModalProps) => {
+  const { onSave, onCancel } = props
+  const modalId = 'addCustomLinkModal'
+
+  const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const data = new FormData(e.currentTarget)
+    const label = `${data.get('bookmarkLabel')}`
+    onSave(label)
+  }
+
+  return (
+    <ModalPortal>
+      <Modal
+        id={modalId}
+        aria-labelledby={`${modalId}-heading`}
+        aria-describedby={`${modalId}-description`}
+        forceAction
+        {...props}>
+        <ModalHeading id={`${modalId}-heading`}>
+          We don’t recognize that link
+        </ModalHeading>
+        <div className="usa-prose">
+          <p id={`${modalId}-description`}>
+            Please provide a title for the custom link you’d like to save.
+          </p>
+        </div>
+
+        <Form onSubmit={handleSave}>
+          <Label htmlFor="bookmarkLabel" className="usa-sr-only">
+            Label
+          </Label>
+          <TextInput
+            type="text"
+            id="bookmarkLabel"
+            name="bookmarkLabel"
+            required
+          />
+          <ButtonGroup>
+            <Button type="submit" data-close-modal>
+              Save link name
+            </Button>
+            <Button
+              type="button"
+              data-close-modal
+              unstyled
+              className="padding-105 text-center"
+              onClick={onCancel}>
+              Cancel
+            </Button>
+          </ButtonGroup>
+        </Form>
+      </Modal>
+    </ModalPortal>
+  )
+}
+
+export default AddCustomLinkModal

--- a/src/components/modals/AddCustomLinkModal.tsx
+++ b/src/components/modals/AddCustomLinkModal.tsx
@@ -17,8 +17,11 @@ type AddCustomLinkModalProps = {
   onCancel: () => void
 } & ModalProps
 
-const AddCustomLinkModal = (props: AddCustomLinkModalProps) => {
-  const { onSave, onCancel } = props
+const AddCustomLinkModal = ({
+  onSave,
+  onCancel,
+  ...props
+}: AddCustomLinkModalProps) => {
   const modalId = 'addCustomLinkModal'
 
   const handleSave = (e: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/util/ModalPortal.tsx
+++ b/src/components/util/ModalPortal.tsx
@@ -1,0 +1,16 @@
+import { useRef, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+const ModalPortal = ({ children }: { children: React.ReactNode }) => {
+  const ref = useRef<Element | null>()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    ref.current = document.querySelector('#modal-root')
+    setMounted(true)
+  }, [])
+
+  return mounted && ref.current ? createPortal(children, ref.current) : null
+}
+
+export default ModalPortal

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,0 +1,18 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class USSFPortalDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <div id="modal-root" />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default USSFPortalDocument

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,7 @@
 
 "@trussworks/react-uswds@https://github.com/trussworks/react-uswds#sr-1233-modal-component":
   version "2.1.0"
-  resolved "https://github.com/trussworks/react-uswds#9c7cf347f311fe8839fbaa6687565a9d283746e0"
+  resolved "https://github.com/trussworks/react-uswds#777e4d0e85ebfbbef9eb0d4a83c9c08a674e77c8"
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3671,10 +3671,9 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@trussworks/react-uswds@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@trussworks/react-uswds/-/react-uswds-2.0.0.tgz#cce2f3062acce8f512143a9a976af56a21c7ae87"
-  integrity sha512-kWLAvAbl/wvFYyM4Y9Uo8AZTOpap/aTu7ckCzz/Lq9Na8jlx5prP3zAyviK9LGHsuCEQ7bUX57/FJMtJukEuKA==
+"@trussworks/react-uswds@https://github.com/trussworks/react-uswds#sr-1233-modal-component":
+  version "2.1.0"
+  resolved "https://github.com/trussworks/react-uswds#89528eabee692b3921ea2d7eb3918c36fddc8100"
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
@@ -11465,7 +11464,7 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
-lodash.debounce@^4.0.7, lodash.debounce@^4.0.8:
+lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -16086,16 +16085,15 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-uswds@2.10.3:
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.10.3.tgz#16d34cee81897762d6d69d3ac83aa55129826fa6"
-  integrity sha512-krNRzx1jRzOJpuH/qtmQhd5zxnXTaDVqrPNYT99sJbxzWUqjb1zZHh3jFNo+xKDpNuiO0XMPwZwlaSp2YdZ3Ag==
+uswds@2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/uswds/-/uswds-2.11.2.tgz#bf5ff132f6324c0939d01b7eefebde340c22dcec"
+  integrity sha512-JISTXCjPIlrufbObIifjrMDn5jF9bbLu7UYhGWmEs9iqB6Z2KDCXHVoBUyzMmIrIjW/UWWYHZzPqOOHO6/IMCQ==
   dependencies:
     classlist-polyfill "^1.0.3"
     del "^6.0.0"
     domready "^1.0.8"
     elem-dataset "^2.0.0"
-    lodash.debounce "^4.0.7"
     object-assign "^4.1.1"
     receptor "^1.0.0"
     resolve-id-refs "^0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,7 @@
 
 "@trussworks/react-uswds@https://github.com/trussworks/react-uswds#sr-1233-modal-component":
   version "2.1.0"
-  resolved "https://github.com/trussworks/react-uswds#89528eabee692b3921ea2d7eb3918c36fddc8100"
+  resolved "https://github.com/trussworks/react-uswds#9c7cf347f311fe8839fbaa6687565a9d283746e0"
 
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"


### PR DESCRIPTION
## Description 

This PR uses a branch of ReactUSWDS that adds the Modal component (https://github.com/trussworks/react-uswds/pull/1622) and sets up a modal root element so we can render modals in the portal app. It builds off https://github.com/USSF-ORBIT/ussf-portal-client/pull/249 to add a modal to that flow where a user can enter a label for a custom link.

Fixes #246 

## Review Notes
