### PR TITLE
feat: Add existing collections to My Space

### DIFF
--- a/cypress/integration/sites-and-applications.spec.js
+++ b/cypress/integration/sites-and-applications.spec.js
@@ -21,6 +21,40 @@ describe('Sites and Applications', () => {
     cy.contains('Application name').should('not.exist')
   })
 
+  it('can add collections from the Sites & Applications page to My Space', () => {
+    cy.contains('My Space')
+    cy.contains('Career').should('not.exist')
+    cy.contains('Medical & Dental').should('not.exist')
+    cy.contains('Life & Fitness').should('not.exist')
+
+    // Go to Sites & Applications
+    cy.contains('All sites & applications').click()
+
+    // Enter select mode
+    cy.findByRole('button', { name: 'Select multiple collections' }).click()
+    cy.findByRole('button', { name: 'Select collection Career' }).click()
+    cy.findByRole('button', {
+      name: 'Select collection Medical & Dental',
+    }).click()
+    cy.findByRole('button', {
+      name: 'Select collection Life & Fitness',
+    }).click()
+    cy.contains('3 collections selected')
+
+    cy.findByRole('button', {
+      name: 'Unselect collection Medical & Dental',
+    }).click()
+    cy.contains('2 collections selected')
+
+    cy.findByRole('button', { name: 'Add selected' }).click()
+
+    // Go back to My Space
+    cy.contains('My Space').click()
+    cy.contains('Career')
+    cy.contains('Life & Fitness')
+    cy.contains('Medical & Dental').should('not.exist')
+  })
+
   it('can hide links from an existing collection', () => {
     cy.contains('My Space')
 

--- a/cypress/integration/sites-and-applications.spec.js
+++ b/cypress/integration/sites-and-applications.spec.js
@@ -28,7 +28,8 @@ describe('Sites and Applications', () => {
     cy.contains('Life & Fitness').should('not.exist')
 
     // Go to Sites & Applications
-    cy.contains('All sites & applications').click()
+    cy.findByRole('link', { name: 'All sites & applications' }).click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/sites-and-applications')
 
     // Enter select mode
     cy.findByRole('button', { name: 'Select multiple collections' }).click()
@@ -49,7 +50,9 @@ describe('Sites and Applications', () => {
     cy.findByRole('button', { name: 'Add selected' }).click()
 
     // Go back to My Space
-    cy.contains('My Space').click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/')
+
+    cy.contains('My Space')
     cy.contains('Career')
     cy.contains('Life & Fitness')
     cy.contains('Medical & Dental').should('not.exist')

--- a/src/__tests__/pages/beta/sites-and-applications.test.tsx
+++ b/src/__tests__/pages/beta/sites-and-applications.test.tsx
@@ -91,6 +91,92 @@ describe('Sites and Applications page', () => {
     )
     expect(screen.queryByRole('table')).not.toBeInTheDocument()
   })
+
+  describe('selecting collections', () => {
+    it('can enter select mode', () => {
+      const selectBtn = screen.getByRole('button', {
+        name: 'Select multiple collections',
+      })
+      expect(selectBtn).toBeInTheDocument()
+      userEvent.click(selectBtn)
+
+      expect(
+        screen.queryByRole('button', { name: 'Select multiple collections' })
+      ).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'Add selected' })
+      ).toBeDisabled()
+      expect(screen.getByText('0 collections selected')).toBeInTheDocument()
+
+      expect(screen.getAllByRole('button', { name: 'Select' })).toHaveLength(
+        mockCollections.length
+      )
+    })
+
+    it('can cancel out of select mode', () => {
+      expect(
+        screen.queryByText('0 collections selected')
+      ).not.toBeInTheDocument()
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select multiple collections',
+        })
+      )
+
+      expect(screen.queryByText('0 collections selected')).toBeInTheDocument()
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+      expect(
+        screen.queryByText('0 collections selected')
+      ).not.toBeInTheDocument()
+    })
+
+    it('can select multiple collections', () => {
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select multiple collections',
+        })
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Add selected' })
+      ).toBeDisabled()
+      expect(screen.getByText('0 collections selected')).toBeInTheDocument()
+      const selectBtns = screen.getAllByRole('button', { name: 'Select' })
+      userEvent.click(selectBtns[0])
+      expect(screen.getByText('1 collection selected')).toBeInTheDocument()
+      userEvent.click(selectBtns[1])
+      expect(screen.getByText('2 collections selected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Add selected' })).toBeEnabled()
+    })
+
+    it('selecting the same collection twice removes it from the selection', () => {
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select multiple collections',
+        })
+      )
+
+      expect(
+        screen.getByRole('button', { name: 'Add selected' })
+      ).toBeDisabled()
+      expect(screen.getByText('0 collections selected')).toBeInTheDocument()
+      const selectBtns = screen.getAllByRole('button', { name: 'Select' })
+      userEvent.click(selectBtns[0])
+      expect(screen.getByText('1 collection selected')).toBeInTheDocument()
+      userEvent.click(selectBtns[1])
+      expect(screen.getByText('2 collections selected')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Add selected' })).toBeEnabled()
+
+      userEvent.click(selectBtns[0])
+      expect(screen.getByText('1 collection selected')).toBeInTheDocument()
+      userEvent.click(selectBtns[1])
+      expect(screen.getByText('0 collections selected')).toBeInTheDocument()
+    })
+  })
 })
 
 describe('getStaticProps', () => {

--- a/src/__tests__/pages/beta/sites-and-applications.test.tsx
+++ b/src/__tests__/pages/beta/sites-and-applications.test.tsx
@@ -3,9 +3,12 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { MockedProvider } from '@apollo/client/testing'
+
 import SitesAndApplications, {
   getStaticProps,
 } from 'pages/beta/sites-and-applications'
+import * as addCollections from 'operations/mutations/addCollections'
 
 const mockBookmarks = [
   {
@@ -53,10 +56,12 @@ const mockCollections = [
 describe('Sites and Applications page', () => {
   beforeEach(() => {
     render(
-      <SitesAndApplications
-        collections={mockCollections}
-        bookmarks={mockBookmarks}
-      />
+      <MockedProvider>
+        <SitesAndApplications
+          collections={mockCollections}
+          bookmarks={mockBookmarks}
+        />
+      </MockedProvider>
     )
   })
 
@@ -141,7 +146,12 @@ describe('Sites and Applications page', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('can select multiple collections', () => {
+    it('can select multiple collections and add them', () => {
+      const addCollectionsSpy = jest.spyOn(
+        addCollections,
+        'useAddCollectionsMutation'
+      )
+
       userEvent.click(
         screen.getByRole('button', {
           name: 'Select multiple collections',
@@ -166,6 +176,7 @@ describe('Sites and Applications page', () => {
       )
       expect(screen.getByText('2 collections selected')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Add selected' })).toBeEnabled()
+      expect(addCollectionsSpy).toHaveBeenCalled()
     })
 
     it('selecting the same collection twice removes it from the selection', () => {

--- a/src/__tests__/pages/beta/sites-and-applications.test.tsx
+++ b/src/__tests__/pages/beta/sites-and-applications.test.tsx
@@ -109,9 +109,9 @@ describe('Sites and Applications page', () => {
       ).toBeDisabled()
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
 
-      expect(screen.getAllByRole('button', { name: 'Select' })).toHaveLength(
-        mockCollections.length
-      )
+      expect(
+        screen.getAllByRole('button', { name: 'Select collection' })
+      ).toHaveLength(mockCollections.length)
     })
 
     it('can cancel out of select mode', () => {
@@ -145,7 +145,9 @@ describe('Sites and Applications page', () => {
         screen.getByRole('button', { name: 'Add selected' })
       ).toBeDisabled()
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
-      const selectBtns = screen.getAllByRole('button', { name: 'Select' })
+      const selectBtns = screen.getAllByRole('button', {
+        name: 'Select collection',
+      })
       userEvent.click(selectBtns[0])
       expect(screen.getByText('1 collection selected')).toBeInTheDocument()
       userEvent.click(selectBtns[1])
@@ -164,7 +166,9 @@ describe('Sites and Applications page', () => {
         screen.getByRole('button', { name: 'Add selected' })
       ).toBeDisabled()
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
-      const selectBtns = screen.getAllByRole('button', { name: 'Select' })
+      const selectBtns = screen.getAllByRole('button', {
+        name: 'Select collection',
+      })
       userEvent.click(selectBtns[0])
       expect(screen.getByText('1 collection selected')).toBeInTheDocument()
       userEvent.click(selectBtns[1])

--- a/src/__tests__/pages/beta/sites-and-applications.test.tsx
+++ b/src/__tests__/pages/beta/sites-and-applications.test.tsx
@@ -110,8 +110,15 @@ describe('Sites and Applications page', () => {
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
 
       expect(
-        screen.getAllByRole('button', { name: 'Select collection' })
-      ).toHaveLength(mockCollections.length)
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 1',
+        })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 2',
+        })
+      ).toBeInTheDocument()
     })
 
     it('can cancel out of select mode', () => {
@@ -145,12 +152,18 @@ describe('Sites and Applications page', () => {
         screen.getByRole('button', { name: 'Add selected' })
       ).toBeDisabled()
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
-      const selectBtns = screen.getAllByRole('button', {
-        name: 'Select collection',
-      })
-      userEvent.click(selectBtns[0])
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 1',
+        })
+      )
       expect(screen.getByText('1 collection selected')).toBeInTheDocument()
-      userEvent.click(selectBtns[1])
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 2',
+        })
+      )
       expect(screen.getByText('2 collections selected')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Add selected' })).toBeEnabled()
     })
@@ -166,18 +179,32 @@ describe('Sites and Applications page', () => {
         screen.getByRole('button', { name: 'Add selected' })
       ).toBeDisabled()
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
-      const selectBtns = screen.getAllByRole('button', {
-        name: 'Select collection',
-      })
-      userEvent.click(selectBtns[0])
+
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 1',
+        })
+      )
       expect(screen.getByText('1 collection selected')).toBeInTheDocument()
-      userEvent.click(selectBtns[1])
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Select collection Example Collection 2',
+        })
+      )
       expect(screen.getByText('2 collections selected')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: 'Add selected' })).toBeEnabled()
 
-      userEvent.click(selectBtns[0])
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Unselect collection Example Collection 1',
+        })
+      )
       expect(screen.getByText('1 collection selected')).toBeInTheDocument()
-      userEvent.click(selectBtns[1])
+      userEvent.click(
+        screen.getByRole('button', {
+          name: 'Unselect collection Example Collection 2',
+        })
+      )
       expect(screen.getByText('0 collections selected')).toBeInTheDocument()
     })
   })

--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -8,7 +8,7 @@
 
   display: flex;
 
-  > a {
+  > :global(.usa-link) {
     flex-grow: 1;
     padding: units('105') units(2);
 
@@ -17,6 +17,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+}
+
+.disabled {
+  pointer-events: none;
 }
 
 .delete {

--- a/src/components/Bookmark/Bookmark.stories.tsx
+++ b/src/components/Bookmark/Bookmark.stories.tsx
@@ -28,3 +28,9 @@ export const WithDeleteHandler = (argTypes: StorybookArgTypes) => (
     Delete Me
   </Bookmark>
 )
+
+export const DisabledLink = () => (
+  <Bookmark href="#" disabled>
+    Example
+  </Bookmark>
+)

--- a/src/components/Bookmark/Bookmark.test.tsx
+++ b/src/components/Bookmark/Bookmark.test.tsx
@@ -50,4 +50,27 @@ describe('Bookmark component', () => {
       expect(await axe(container)).toHaveNoViolations()
     })
   })
+
+  describe('when disabled', () => {
+    it('renders static text instead of a link', () => {
+      render(
+        <Bookmark href="/home" disabled>
+          Home
+        </Bookmark>
+      )
+
+      expect(screen.queryByRole('link')).not.toBeInTheDocument()
+      expect(screen.getByText('Home')).toBeInstanceOf(HTMLSpanElement)
+    })
+
+    it('has no a11y violations', async () => {
+      const { container } = render(
+        <Bookmark href="/home" disabled>
+          Home
+        </Bookmark>
+      )
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
 })

--- a/src/components/Bookmark/Bookmark.tsx
+++ b/src/components/Bookmark/Bookmark.tsx
@@ -6,6 +6,7 @@ import LinkTo, { PropTypes as LinkToProps } from 'components/util/LinkTo/LinkTo'
 
 type PropTypes = LinkToProps & {
   onDelete?: (event: React.MouseEvent<HTMLButtonElement>) => void
+  disabled?: boolean
 }
 
 const Bookmark = ({
@@ -13,21 +14,32 @@ const Bookmark = ({
   className,
   onDelete,
   href,
+  disabled,
   ...linkProps
 }: PropTypes) => {
-  const linkClasses = classnames('usa-link', className)
+  const linkClasses = classnames(
+    'usa-link',
+    {
+      [styles.disabled]: disabled,
+    },
+    className
+  )
 
   return (
     <div className={styles.bookmark}>
-      <LinkTo
-        {...linkProps}
-        href={href}
-        className={linkClasses}
-        rel="noreferrer noopener"
-        target="_blank">
-        {children}
-        <span className="usa-sr-only">(opens in a new window)</span>
-      </LinkTo>
+      {disabled ? (
+        <span className={linkClasses}>{children}</span>
+      ) : (
+        <LinkTo
+          {...linkProps}
+          href={href}
+          className={linkClasses}
+          rel="noreferrer noopener"
+          target="_blank">
+          {children}
+          <span className="usa-sr-only">(opens in a new window)</span>
+        </LinkTo>
+      )}
 
       {onDelete && (
         <button

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -28,7 +28,7 @@ const CustomCollection = ({
   handleAddBookmark,
 }: PropTypes) => {
   const [isAdding, setIsAdding] = useState<boolean>(false)
-  const urlInputValue = useRef<string>()
+  const urlInputValue = useRef<string>('')
   const addCustomLinkModal = useRef<ModalRef>(null)
 
   const handleShowAdding = () => setIsAdding(true)
@@ -49,12 +49,8 @@ const CustomCollection = ({
   }
 
   const handleSaveBookmark = (label: string) => {
-    if (urlInputValue.current) {
-      handleAddBookmark(urlInputValue.current, label)
-      urlInputValue.current = ''
-    } else {
-      // need a URL value
-    }
+    handleAddBookmark(urlInputValue.current, label)
+    urlInputValue.current = ''
 
     setIsAdding(false)
     addCustomLinkModal.current?.toggleModal(undefined, false)

--- a/src/components/CustomCollection/RemovableBookmark.tsx
+++ b/src/components/CustomCollection/RemovableBookmark.tsx
@@ -21,7 +21,7 @@ export const RemovableBookmark = ({
   const [isHidden, setHidden] = useState<boolean>(false)
 
   const handleDeleteBookmark = () => {
-    if (!isHidden) setHidden(true)
+    setHidden(true)
   }
 
   const handleUndoDelete = () => {

--- a/src/components/SelectableCollection/SelectableCollection.module.scss
+++ b/src/components/SelectableCollection/SelectableCollection.module.scss
@@ -1,4 +1,5 @@
 @import 'styles/uswdsDependencies';
+@import 'styles/deps';
 
 .disabled {
   pointer-events: none;
@@ -9,8 +10,12 @@
 }
 
 .selectable {
+  @extend %button-reset;
   position: relative;
   margin-bottom: units(3);
+  text-align: left;
+  width: 100%;
+  line-height: 1.15;
 
   &.selected {
     .disabled {
@@ -21,7 +26,9 @@
     }
   }
 
-  &:hover {
+  &:hover,
+  &:focus,
+  &:focus-within {
     .overlay {
       opacity: 1;
     }

--- a/src/components/SelectableCollection/SelectableCollection.module.scss
+++ b/src/components/SelectableCollection/SelectableCollection.module.scss
@@ -10,7 +10,7 @@
 }
 
 .selectable {
-  @extend %button-reset;
+  display: block;
   position: relative;
   margin-bottom: units(3);
   text-align: left;

--- a/src/components/SelectableCollection/SelectableCollection.module.scss
+++ b/src/components/SelectableCollection/SelectableCollection.module.scss
@@ -38,6 +38,6 @@
   align-items: center;
   justify-content: center;
   opacity: 0;
-  transition: opacity 0.2s;
+  transition: opacity 0.12s;
   background-color: rgba(236, 240, 245, 0.8);
 }

--- a/src/components/SelectableCollection/SelectableCollection.module.scss
+++ b/src/components/SelectableCollection/SelectableCollection.module.scss
@@ -1,0 +1,43 @@
+@import 'styles/uswdsDependencies';
+
+.disabled {
+  pointer-events: none;
+
+  > * {
+    margin: 0;
+  }
+}
+
+.selectable {
+  position: relative;
+  margin-bottom: units(3);
+
+  &.selected {
+    .disabled {
+      > * {
+        border: 4px solid #005ea2;
+        border-radius: 4px;
+      }
+    }
+  }
+
+  &:hover {
+    .overlay {
+      opacity: 1;
+    }
+  }
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+  background-color: rgba(236, 240, 245, 0.8);
+}

--- a/src/components/SelectableCollection/SelectableCollection.stories.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
+import { v4 } from 'uuid'
+
 import SelectableCollection from './SelectableCollection'
-import Collection from 'components/Collection/Collection'
-import Bookmark from 'components/Bookmark/Bookmark'
 
 type StorybookArgTypes = {
   handleSelect: () => void
@@ -16,46 +16,43 @@ export default {
   },
 } as Meta
 
+const exampleCollection = {
+  id: v4(),
+  title: 'Example Collection',
+  bookmarks: [
+    {
+      id: v4(),
+      url: 'https://google.com',
+      label: 'Webmail',
+      description: 'Lorem ipsum',
+    },
+    {
+      id: v4(),
+      url: 'https://mypay.dfas.mil/#/',
+      label: 'MyPay',
+      description: 'Lorem ipsum',
+    },
+    {
+      id: v4(),
+      url: 'https://afpcsecure.us.af.mil/PKI/MainMenu1.aspx',
+      label: 'vMPF',
+      description: 'Lorem ipsum',
+    },
+  ],
+}
+
 export const Unselected = (argTypes: StorybookArgTypes) => (
-  <SelectableCollection isSelected={false} onSelect={argTypes.handleSelect}>
-    <Collection title="Example collection">
-      <Bookmark key="link1" href="#">
-        Webmail
-      </Bookmark>
-      <Bookmark key="link2" href="#">
-        MyPay
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        vMPF
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        LeaveWeb
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        e-Publications
-      </Bookmark>
-    </Collection>
-  </SelectableCollection>
+  <SelectableCollection
+    {...exampleCollection}
+    isSelected={false}
+    onSelect={argTypes.handleSelect}
+  />
 )
 
 export const Selected = (argTypes: StorybookArgTypes) => (
-  <SelectableCollection isSelected={true} onSelect={argTypes.handleSelect}>
-    <Collection title="Example collection">
-      <Bookmark key="link1" href="#">
-        Webmail
-      </Bookmark>
-      <Bookmark key="link2" href="#">
-        MyPay
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        vMPF
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        LeaveWeb
-      </Bookmark>
-      <Bookmark key="link3" href="#">
-        e-Publications
-      </Bookmark>
-    </Collection>
-  </SelectableCollection>
+  <SelectableCollection
+    {...exampleCollection}
+    isSelected={true}
+    onSelect={argTypes.handleSelect}
+  />
 )

--- a/src/components/SelectableCollection/SelectableCollection.stories.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.stories.tsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import SelectableCollection from './SelectableCollection'
+import Collection from 'components/Collection/Collection'
+import Bookmark from 'components/Bookmark/Bookmark'
+
+type StorybookArgTypes = {
+  handleSelect: () => void
+}
+
+export default {
+  title: 'Components/SelectableCollection',
+  component: SelectableCollection,
+  argTypes: {
+    handleSelect: { action: 'Select collection' },
+  },
+} as Meta
+
+export const Unselected = (argTypes: StorybookArgTypes) => (
+  <SelectableCollection isSelected={false} onSelect={argTypes.handleSelect}>
+    <Collection title="Example collection">
+      <Bookmark key="link1" href="#">
+        Webmail
+      </Bookmark>
+      <Bookmark key="link2" href="#">
+        MyPay
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        vMPF
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        LeaveWeb
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        e-Publications
+      </Bookmark>
+    </Collection>
+  </SelectableCollection>
+)
+
+export const Selected = (argTypes: StorybookArgTypes) => (
+  <SelectableCollection isSelected={true} onSelect={argTypes.handleSelect}>
+    <Collection title="Example collection">
+      <Bookmark key="link1" href="#">
+        Webmail
+      </Bookmark>
+      <Bookmark key="link2" href="#">
+        MyPay
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        vMPF
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        LeaveWeb
+      </Bookmark>
+      <Bookmark key="link3" href="#">
+        e-Publications
+      </Bookmark>
+    </Collection>
+  </SelectableCollection>
+)

--- a/src/components/SelectableCollection/SelectableCollection.test.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import React from 'react'
+
+import SelectableCollection from './SelectableCollection'
+
+describe('SelectableCollection component', () => {
+  it('renders its children in a button', () => {
+    const mockOnSelect = jest.fn()
+
+    render(
+      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
+        Example Collection
+      </SelectableCollection>
+    )
+
+    expect(screen.getByText('Example Collection')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Select collection' })
+    ).toBeInTheDocument()
+  })
+
+  it('clicking the button calls the select handler', () => {
+    const mockOnSelect = jest.fn()
+
+    render(
+      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
+        Example Collection
+      </SelectableCollection>
+    )
+
+    userEvent.click(screen.getByRole('button', { name: 'Select collection' }))
+    expect(mockOnSelect).toBeCalled()
+  })
+
+  it('the select handler is keyboard accessible', () => {
+    const mockOnSelect = jest.fn()
+
+    render(
+      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
+        Example Collection
+      </SelectableCollection>
+    )
+
+    userEvent.tab()
+    expect(
+      screen.getByRole('button', { name: 'Select collection' })
+    ).toHaveFocus()
+    userEvent.keyboard('{enter}')
+    expect(mockOnSelect).toBeCalled()
+  })
+
+  it('has no a11y violations', async () => {
+    const { container } = render(
+      <SelectableCollection isSelected={false} onSelect={jest.fn()}>
+        Example Collection
+      </SelectableCollection>
+    )
+
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  describe('when selected', () => {
+    it('renders an unselect button that appears on focus', () => {
+      const mockOnSelect = jest.fn()
+
+      render(
+        <SelectableCollection isSelected={true} onSelect={mockOnSelect}>
+          Example Collection
+        </SelectableCollection>
+      )
+
+      userEvent.tab()
+      expect(
+        screen.getByRole('button', { name: 'Unselect collection' })
+      ).toHaveFocus()
+      userEvent.click(
+        screen.getByRole('button', { name: 'Unselect collection' })
+      )
+      expect(mockOnSelect).toBeCalled()
+    })
+
+    it('has no a11y violations', async () => {
+      const { container } = render(
+        <SelectableCollection isSelected={true} onSelect={jest.fn()}>
+          Example Collection
+        </SelectableCollection>
+      )
+
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+})

--- a/src/components/SelectableCollection/SelectableCollection.test.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.test.tsx
@@ -6,22 +6,61 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import React from 'react'
+import { v4 } from 'uuid'
 
 import SelectableCollection from './SelectableCollection'
 
+const exampleCollection = {
+  id: v4(),
+  title: 'Example Collection',
+  bookmarks: [
+    {
+      id: v4(),
+      url: 'https://google.com',
+      label: 'Webmail',
+      description: 'Lorem ipsum',
+    },
+    {
+      id: v4(),
+      url: 'https://mypay.dfas.mil/#/',
+      label: 'MyPay',
+      description: 'Lorem ipsum',
+    },
+    {
+      id: v4(),
+      url: 'https://afpcsecure.us.af.mil/PKI/MainMenu1.aspx',
+      label: 'vMPF',
+      description: 'Lorem ipsum',
+    },
+  ],
+}
+
 describe('SelectableCollection component', () => {
-  it('renders its children in a button', () => {
+  it('renders the collection with disabled links and a select button', () => {
     const mockOnSelect = jest.fn()
 
     render(
-      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
-        Example Collection
-      </SelectableCollection>
+      <SelectableCollection
+        {...exampleCollection}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
     )
 
-    expect(screen.getByText('Example Collection')).toBeInTheDocument()
+    expect(screen.getByRole('list')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+      exampleCollection.title
+    )
+    expect(screen.getAllByRole('listitem')).toHaveLength(
+      exampleCollection.bookmarks.length
+    )
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument()
+
     expect(
-      screen.getByRole('button', { name: 'Select collection' })
+      screen.getByRole('button', {
+        name: 'Select collection Example Collection',
+      })
     ).toBeInTheDocument()
   })
 
@@ -29,12 +68,18 @@ describe('SelectableCollection component', () => {
     const mockOnSelect = jest.fn()
 
     render(
-      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
-        Example Collection
-      </SelectableCollection>
+      <SelectableCollection
+        {...exampleCollection}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
     )
 
-    userEvent.click(screen.getByRole('button', { name: 'Select collection' }))
+    userEvent.click(
+      screen.getByRole('button', {
+        name: 'Select collection Example Collection',
+      })
+    )
     expect(mockOnSelect).toBeCalled()
   })
 
@@ -42,14 +87,18 @@ describe('SelectableCollection component', () => {
     const mockOnSelect = jest.fn()
 
     render(
-      <SelectableCollection isSelected={false} onSelect={mockOnSelect}>
-        Example Collection
-      </SelectableCollection>
+      <SelectableCollection
+        {...exampleCollection}
+        isSelected={false}
+        onSelect={mockOnSelect}
+      />
     )
 
     userEvent.tab()
     expect(
-      screen.getByRole('button', { name: 'Select collection' })
+      screen.getByRole('button', {
+        name: 'Select collection Example Collection',
+      })
     ).toHaveFocus()
     userEvent.keyboard('{enter}')
     expect(mockOnSelect).toBeCalled()
@@ -57,9 +106,11 @@ describe('SelectableCollection component', () => {
 
   it('has no a11y violations', async () => {
     const { container } = render(
-      <SelectableCollection isSelected={false} onSelect={jest.fn()}>
-        Example Collection
-      </SelectableCollection>
+      <SelectableCollection
+        {...exampleCollection}
+        isSelected={false}
+        onSelect={jest.fn()}
+      />
     )
 
     expect(await axe(container)).toHaveNoViolations()
@@ -70,26 +121,34 @@ describe('SelectableCollection component', () => {
       const mockOnSelect = jest.fn()
 
       render(
-        <SelectableCollection isSelected={true} onSelect={mockOnSelect}>
-          Example Collection
-        </SelectableCollection>
+        <SelectableCollection
+          {...exampleCollection}
+          isSelected={true}
+          onSelect={mockOnSelect}
+        />
       )
 
       userEvent.tab()
       expect(
-        screen.getByRole('button', { name: 'Unselect collection' })
+        screen.getByRole('button', {
+          name: 'Unselect collection Example Collection',
+        })
       ).toHaveFocus()
       userEvent.click(
-        screen.getByRole('button', { name: 'Unselect collection' })
+        screen.getByRole('button', {
+          name: 'Unselect collection Example Collection',
+        })
       )
       expect(mockOnSelect).toBeCalled()
     })
 
     it('has no a11y violations', async () => {
       const { container } = render(
-        <SelectableCollection isSelected={true} onSelect={jest.fn()}>
-          Example Collection
-        </SelectableCollection>
+        <SelectableCollection
+          {...exampleCollection}
+          isSelected={true}
+          onSelect={jest.fn()}
+        />
       )
 
       expect(await axe(container)).toHaveNoViolations()

--- a/src/components/SelectableCollection/SelectableCollection.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.tsx
@@ -28,7 +28,7 @@ const SelectableCollection = ({
       <div className={styles.disabled}>{children}</div>
       <div className={styles.overlay}>
         <Button type="button" outline onClick={handleSelect}>
-          Select
+          {isSelected ? 'Unselect' : 'Select'}
         </Button>
       </div>
     </div>

--- a/src/components/SelectableCollection/SelectableCollection.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.tsx
@@ -1,18 +1,27 @@
 import React from 'react'
 import classnames from 'classnames'
+import { Button } from '@trussworks/react-uswds'
 
 import styles from './SelectableCollection.module.scss'
 
+import Collection from 'components/Collection/Collection'
+import Bookmark from 'components/Bookmark/Bookmark'
+import type { Bookmark as BookmarkType } from 'types/index'
+
 type SelectableCollectionProps = {
+  id: string
+  title: string
+  bookmarks: BookmarkType[]
   onSelect: () => void
   isSelected: boolean
-  children: React.ReactNode | React.ReactNode[]
 }
 
 const SelectableCollection = ({
+  id,
+  title,
+  bookmarks,
   onSelect,
   isSelected,
-  children,
 }: SelectableCollectionProps) => {
   const handleSelect = () => {
     onSelect()
@@ -22,24 +31,35 @@ const SelectableCollection = ({
     [styles.selected]: isSelected,
   })
 
-  // TODO - try label?
-  // Explicitly render collection & bookmarks in here
-
-  const ariaLabel = isSelected ? 'Unselect collection' : 'Select collection'
+  const ariaLabel = isSelected
+    ? `Unselect collection ${title}`
+    : `Select collection ${title}`
 
   return (
-    <button
-      type="button"
-      className={classes}
-      onClick={handleSelect}
-      aria-label={ariaLabel}>
-      <div className={styles.disabled}>{children}</div>
-      <div className={styles.overlay}>
-        <div className="usa-button usa-button--outline">
-          {isSelected ? 'Unselect' : 'Select'}
-        </div>
+    <label htmlFor={`selectCollection_${id}`} className={classes}>
+      <div className={styles.disabled}>
+        <Collection title={title}>
+          {bookmarks.map((bookmark) => (
+            <Bookmark
+              key={`bookmark_${bookmark.id}`}
+              href={bookmark.url}
+              disabled>
+              {bookmark.label}
+            </Bookmark>
+          ))}
+        </Collection>
       </div>
-    </button>
+      <div className={styles.overlay}>
+        <Button
+          id={`selectCollection_${id}`}
+          type="button"
+          onClick={handleSelect}
+          aria-label={ariaLabel}
+          className="usa-button usa-button--outline">
+          {isSelected ? 'Unselect' : 'Select'}
+        </Button>
+      </div>
+    </label>
   )
 }
 

--- a/src/components/SelectableCollection/SelectableCollection.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import classnames from 'classnames'
+import { Button } from '@trussworks/react-uswds'
+
+import styles from './SelectableCollection.module.scss'
+
+type SelectableCollectionProps = {
+  onSelect: () => void
+  isSelected: boolean
+  children: React.ReactNode | React.ReactNode[]
+}
+
+const SelectableCollection = ({
+  onSelect,
+  isSelected,
+  children,
+}: SelectableCollectionProps) => {
+  const handleSelect = () => {
+    onSelect()
+  }
+
+  const classes = classnames(styles.selectable, {
+    [styles.selected]: isSelected,
+  })
+
+  return (
+    <div className={classes}>
+      <div className={styles.disabled}>{children}</div>
+      <div className={styles.overlay}>
+        <Button type="button" outline onClick={handleSelect}>
+          Select
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default SelectableCollection

--- a/src/components/SelectableCollection/SelectableCollection.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import classnames from 'classnames'
-import { Button } from '@trussworks/react-uswds'
 
 import styles from './SelectableCollection.module.scss'
 
@@ -23,15 +22,24 @@ const SelectableCollection = ({
     [styles.selected]: isSelected,
   })
 
+  // TODO - try label?
+  // Explicitly render collection & bookmarks in here
+
+  const ariaLabel = isSelected ? 'Unselect collection' : 'Select collection'
+
   return (
-    <div className={classes}>
+    <button
+      type="button"
+      className={classes}
+      onClick={handleSelect}
+      aria-label={ariaLabel}>
       <div className={styles.disabled}>{children}</div>
       <div className={styles.overlay}>
-        <Button type="button" outline onClick={handleSelect}>
+        <div className="usa-button usa-button--outline">
           {isSelected ? 'Unselect' : 'Select'}
-        </Button>
+        </div>
       </div>
-    </div>
+    </button>
   )
 }
 

--- a/src/components/modals/AddCustomLinkModal.tsx
+++ b/src/components/modals/AddCustomLinkModal.tsx
@@ -28,16 +28,21 @@ const AddCustomLinkModal = ({
   const modalId = 'addCustomLinkModal'
   const inputRef = useRef<HTMLInputElement>(null)
 
+  const resetForm = () => {
+    const inputEl = inputRef.current as HTMLInputElement
+    inputEl.value = ''
+  }
+
   const handleSave = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     const data = new FormData(e.currentTarget)
     const label = `${data.get('bookmarkLabel')}`
-    if (inputRef.current) inputRef.current.value = ''
+    resetForm()
     onSave(label)
   }
 
   const handleCancel = () => {
-    if (inputRef.current) inputRef.current.value = ''
+    resetForm()
     onCancel()
   }
 

--- a/src/operations/mutations/addCollections.tsx
+++ b/src/operations/mutations/addCollections.tsx
@@ -1,0 +1,22 @@
+import { gql, useMutation } from '@apollo/client'
+import type { Collection } from 'types'
+
+interface AddCollectionsResponse {
+  collections: Collection[]
+}
+
+interface AddCollectionsInput {
+  collections: Collection[]
+}
+
+export const ADD_COLLECTIONS = gql`
+  mutation addCollections($collections: [Collection]) {
+    addCollections(collections: $collections) @client
+  }
+`
+
+export function useAddCollectionsMutation() {
+  return useMutation<AddCollectionsResponse, AddCollectionsInput>(
+    ADD_COLLECTIONS
+  )
+}

--- a/src/operations/resolvers.tsx
+++ b/src/operations/resolvers.tsx
@@ -37,6 +37,32 @@ export const localResolvers: Resolvers = {
       cache.writeQuery({ query: GET_COLLECTIONS, data })
       return newCollection
     },
+    addCollections: (_root, { collections }, { cache }) => {
+      const previous = cache.readQuery({
+        query: GET_COLLECTIONS,
+      })
+
+      const newCollections = collections.map((collection: Collection) => ({
+        id: v4(),
+        title: collection.title,
+        bookmarks: collection.bookmarks.map((bookmark) => ({
+          __typename: 'Bookmark',
+          description: '',
+          ...bookmark,
+        })),
+        __typename: 'Collection',
+      }))
+
+      const data = {
+        collections:
+          previous.collections.length !== 0
+            ? [...previous.collections, ...newCollections]
+            : [...newCollections],
+      }
+
+      cache.writeQuery({ query: GET_COLLECTIONS, data })
+      return newCollections
+    },
     removeCollection: (_root, { id }, { cache }) => {
       cache.modify({
         fields: {

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -16,24 +16,57 @@ import styles from 'styles/pages/sitesAndApplications.module.scss'
 
 type SortBy = 'SORT_TYPE' | 'SORT_ALPHA'
 
+type SelectedCollections = string[]
+
 const SitesAndApplications = ({
   collections,
   bookmarks,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const [sortBy, setSort] = useState<SortBy>('SORT_TYPE')
   const [selectMode, setSelectMode] = useState<boolean>(false)
+  const [selectedCollections, setSelectedCollections] =
+    useState<SelectedCollections>([])
 
   const handleSortClick = (sortType: SortBy) => setSort(sortType)
 
-  const handleToggleSelectMode = () =>
+  const handleToggleSelectMode = () => {
     setSelectMode((currentMode) => !currentMode)
+    setSelectedCollections([])
+  }
 
   const widgetClasses = classnames(styles.widgetContainer, {
     [styles.selectMode]: selectMode,
   })
 
-  const handleSelectCollection = () => {
-    /* TODO */
+  const handleSelectCollection = (id?: string): void => {
+    if (!id) {
+      // error
+      return
+    }
+
+    if (isSelected(id)) {
+      setSelectedCollections((state) => {
+        const itemIndex = state.indexOf(id)
+        const newState = [...state]
+        newState.splice(itemIndex, 1)
+        return newState
+      })
+    } else {
+      setSelectedCollections((state) => [...state, id])
+    }
+  }
+
+  const isSelected = (id?: string): boolean => {
+    if (!id) {
+      // error
+      return false
+    }
+
+    return selectedCollections.indexOf(id) > -1
+  }
+
+  const handleAddSelected = () => {
+    // TODO
   }
 
   return (
@@ -65,6 +98,18 @@ const SitesAndApplications = ({
           <div className={styles.widgetToolbar}>
             {selectMode ? (
               <>
+                <span>
+                  {selectedCollections.length} collection
+                  {selectedCollections.length !== 1 && 's'} selected
+                </span>
+                <Button
+                  type="button"
+                  accentStyle="warm"
+                  inverse
+                  disabled={selectedCollections.length < 1}
+                  onClick={handleAddSelected}>
+                  Add selected
+                </Button>
                 <Button type="button" outline onClick={handleToggleSelectMode}>
                   Cancel
                 </Button>
@@ -97,8 +142,8 @@ const SitesAndApplications = ({
                   desktop={{ col: 3 }}>
                   {selectMode ? (
                     <SelectableCollection
-                      isSelected={false}
-                      onSelect={handleSelectCollection}>
+                      isSelected={isSelected(collection.id)}
+                      onSelect={() => handleSelectCollection(collection.id)}>
                       {collectionComponent}
                     </SelectableCollection>
                   ) : (

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -123,19 +123,6 @@ const SitesAndApplications = ({
 
           <Grid row gap className={styles.widgets}>
             {collections.map((collection) => {
-              const collectionComponent = (
-                <Collection title={collection.title}>
-                  {collection.bookmarks?.map((bookmark) => (
-                    <Bookmark
-                      key={`bookmark_${bookmark.id}`}
-                      href={bookmark.url}
-                      disabled={selectMode}>
-                      {bookmark.label}
-                    </Bookmark>
-                  ))}
-                </Collection>
-              )
-
               return (
                 <Grid
                   key={`collection_${collection.id}`}
@@ -143,12 +130,22 @@ const SitesAndApplications = ({
                   desktop={{ col: 3 }}>
                   {selectMode ? (
                     <SelectableCollection
+                      id={collection.id || ''}
+                      title={collection.title || ''}
+                      bookmarks={collection.bookmarks || []}
                       isSelected={isSelected(collection.id)}
-                      onSelect={() => handleSelectCollection(collection.id)}>
-                      {collectionComponent}
-                    </SelectableCollection>
+                      onSelect={() => handleSelectCollection(collection.id)}
+                    />
                   ) : (
-                    collectionComponent
+                    <Collection title={collection.title}>
+                      {collection.bookmarks?.map((bookmark) => (
+                        <Bookmark
+                          key={`bookmark_${bookmark.id}`}
+                          href={bookmark.url}>
+                          {bookmark.label}
+                        </Bookmark>
+                      ))}
+                    </Collection>
                   )}
                 </Grid>
               )

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { InferGetStaticPropsType } from 'next'
-import { Grid } from '@trussworks/react-uswds'
+import { Button, Grid } from '@trussworks/react-uswds'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import classnames from 'classnames'
 
 import { lists } from '.keystone/api'
 
@@ -19,8 +20,16 @@ const SitesAndApplications = ({
   bookmarks,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const [sortBy, setSort] = useState<SortBy>('SORT_TYPE')
+  const [selectMode, setSelectMode] = useState<boolean>(false)
 
   const handleSortClick = (sortType: SortBy) => setSort(sortType)
+
+  const handleToggleSelectMode = () =>
+    setSelectMode((currentMode) => !currentMode)
+
+  const widgetClasses = classnames(styles.widgetContainer, {
+    [styles.selectMode]: selectMode,
+  })
 
   return (
     <>
@@ -30,7 +39,7 @@ const SitesAndApplications = ({
         <button
           type="button"
           className={styles.sortButton}
-          disabled={sortBy === 'SORT_ALPHA'}
+          disabled={sortBy === 'SORT_ALPHA' || selectMode}
           onClick={() => handleSortClick('SORT_ALPHA')}>
           <FontAwesomeIcon icon="list" /> Sort alphabetically
         </button>
@@ -47,8 +56,22 @@ const SitesAndApplications = ({
       {sortBy === 'SORT_ALPHA' && <BookmarkList bookmarks={bookmarks} />}
 
       {sortBy === 'SORT_TYPE' && (
-        <div className={styles.widgetContainer}>
-          <Grid row gap>
+        <div className={widgetClasses}>
+          <div className={styles.widgetToolbar}>
+            {selectMode ? (
+              <>
+                <Button type="button" outline onClick={handleToggleSelectMode}>
+                  Cancel
+                </Button>
+              </>
+            ) : (
+              <Button type="button" onClick={handleToggleSelectMode}>
+                Select multiple collections
+              </Button>
+            )}
+          </div>
+
+          <Grid row gap className={styles.widgets}>
             {collections.map((collection) => (
               <Grid
                 key={`collection_${collection.id}`}

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -128,7 +128,8 @@ const SitesAndApplications = ({
                   {collection.bookmarks?.map((bookmark) => (
                     <Bookmark
                       key={`bookmark_${bookmark.id}`}
-                      href={bookmark.url}>
+                      href={bookmark.url}
+                      disabled={selectMode}>
                       {bookmark.label}
                     </Bookmark>
                   ))}

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -6,13 +6,18 @@ import classnames from 'classnames'
 
 import { lists } from '.keystone/api'
 
-import type { BookmarkRecords, CollectionRecords } from 'types/index'
+import type {
+  BookmarkRecords,
+  CollectionRecords,
+  Collection as CollectionType,
+} from 'types/index'
 import { withBetaLayout } from 'layout/Beta/DefaultLayout/DefaultLayout'
 import Collection from 'components/Collection/Collection'
 import Bookmark from 'components/Bookmark/Bookmark'
 import BookmarkList from 'components/BookmarkList/BookmarkList'
 import SelectableCollection from 'components/SelectableCollection/SelectableCollection'
 import styles from 'styles/pages/sitesAndApplications.module.scss'
+import { useAddCollectionsMutation } from 'operations/mutations/addCollections'
 
 type SortBy = 'SORT_TYPE' | 'SORT_ALPHA'
 
@@ -26,6 +31,7 @@ const SitesAndApplications = ({
   const [selectMode, setSelectMode] = useState<boolean>(false)
   const [selectedCollections, setSelectedCollections] =
     useState<SelectedCollections>([])
+  const [handleAddCollections] = useAddCollectionsMutation()
 
   const handleSortClick = (sortType: SortBy) => setSort(sortType)
 
@@ -66,7 +72,17 @@ const SitesAndApplications = ({
   }
 
   const handleAddSelected = () => {
-    // TODO
+    const collectionObjs = selectedCollections.map((id) =>
+      collections.find((i) => i.id === id)
+    ) as CollectionType[]
+
+    handleAddCollections({
+      variables: {
+        collections: collectionObjs,
+      },
+    })
+    setSelectMode(false)
+    setSelectedCollections([])
   }
 
   return (

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -3,6 +3,7 @@ import { InferGetStaticPropsType } from 'next'
 import { Button, Grid } from '@trussworks/react-uswds'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import classnames from 'classnames'
+import { useRouter } from 'next/router'
 
 import { lists } from '.keystone/api'
 
@@ -27,6 +28,7 @@ const SitesAndApplications = ({
   collections,
   bookmarks,
 }: InferGetStaticPropsType<typeof getStaticProps>) => {
+  const router = useRouter()
   const [sortBy, setSort] = useState<SortBy>('SORT_TYPE')
   const [selectMode, setSelectMode] = useState<boolean>(false)
   const [selectedCollections, setSelectedCollections] =
@@ -83,6 +85,7 @@ const SitesAndApplications = ({
     })
     setSelectMode(false)
     setSelectedCollections([])
+    router.push('/')
   }
 
   return (

--- a/src/pages/beta/sites-and-applications.tsx
+++ b/src/pages/beta/sites-and-applications.tsx
@@ -11,6 +11,7 @@ import { withBetaLayout } from 'layout/Beta/DefaultLayout/DefaultLayout'
 import Collection from 'components/Collection/Collection'
 import Bookmark from 'components/Bookmark/Bookmark'
 import BookmarkList from 'components/BookmarkList/BookmarkList'
+import SelectableCollection from 'components/SelectableCollection/SelectableCollection'
 import styles from 'styles/pages/sitesAndApplications.module.scss'
 
 type SortBy = 'SORT_TYPE' | 'SORT_ALPHA'
@@ -30,6 +31,10 @@ const SitesAndApplications = ({
   const widgetClasses = classnames(styles.widgetContainer, {
     [styles.selectMode]: selectMode,
   })
+
+  const handleSelectCollection = () => {
+    /* TODO */
+  }
 
   return (
     <>
@@ -72,11 +77,8 @@ const SitesAndApplications = ({
           </div>
 
           <Grid row gap className={styles.widgets}>
-            {collections.map((collection) => (
-              <Grid
-                key={`collection_${collection.id}`}
-                tablet={{ col: 6 }}
-                desktop={{ col: 3 }}>
+            {collections.map((collection) => {
+              const collectionComponent = (
                 <Collection title={collection.title}>
                   {collection.bookmarks?.map((bookmark) => (
                     <Bookmark
@@ -86,8 +88,25 @@ const SitesAndApplications = ({
                     </Bookmark>
                   ))}
                 </Collection>
-              </Grid>
-            ))}
+              )
+
+              return (
+                <Grid
+                  key={`collection_${collection.id}`}
+                  tablet={{ col: 6 }}
+                  desktop={{ col: 3 }}>
+                  {selectMode ? (
+                    <SelectableCollection
+                      isSelected={false}
+                      onSelect={handleSelectCollection}>
+                      {collectionComponent}
+                    </SelectableCollection>
+                  ) : (
+                    collectionComponent
+                  )}
+                </Grid>
+              )
+            })}
           </Grid>
         </div>
       )}

--- a/src/styles/pages/sitesAndApplications.module.scss
+++ b/src/styles/pages/sitesAndApplications.module.scss
@@ -21,7 +21,23 @@
   border: 1px solid color('base-light');
   border-radius: 4px;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
-  padding: units(4) units(4) units(6);
+
+  &.selectMode {
+    border: 4px solid #669ec7;
+
+    .widgetToolbar {
+      background-color: #669ec7;
+    }
+  }
+
+  .widgets {
+    margin: units(4) units(4) units(6);
+  }
+}
+
+.widgetToolbar {
+  display: flex;
+  justify-content: flex-end;
 }
 
 .sortButton {

--- a/src/styles/pages/sitesAndApplications.module.scss
+++ b/src/styles/pages/sitesAndApplications.module.scss
@@ -40,6 +40,22 @@
 .widgetToolbar {
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  color: #fff;
+  padding: units(1) units(4) units('105');
+
+  > * + * {
+    margin-left: units('105');
+    margin-right: (0);
+  }
+
+  :global(.usa-button--inverse) {
+    color: #fff;
+  }
+
+  :global(.usa-button--outline) {
+    background-color: #fff;
+  }
 }
 
 .sortButton {

--- a/src/styles/pages/sitesAndApplications.module.scss
+++ b/src/styles/pages/sitesAndApplications.module.scss
@@ -19,11 +19,13 @@
 
 .widgetContainer {
   border: 1px solid color('base-light');
+  padding: 3px;
   border-radius: 4px;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
 
   &.selectMode {
     border: 4px solid #669ec7;
+    padding: 0px;
 
     .widgetToolbar {
       background-color: #669ec7;


### PR DESCRIPTION
## Description 

This PR adds the UX flow to select existing collections from the Sites & Applications page, and add them to a user's My Space. This includes:
*  A "select" state on the Sites & Applications page that renders each collection as selectable buttons, and any links contained within are not clickable.
* A mutation to add multiple collections in a single operation

Fixes #235 

## Review Notes

* Even though it wasn't specified in the design, I added an "unselect" handler if you click a collection that has already been selected.
* Since the collections are only stored in the local cache, refreshing the page will reset any changes you've made.
* One thing this PR does _not_ implement is storing references to CMS-managed collections -- it simply copies the data from a collection into a user's customized My Space. This means if a user saves a collection and then changes to that collection are made in the CMS, they will not be changed in the user's version as well. Implementing that will require some additional architectural work to determine how the CMS & app databases/APIs might interact. I will create follow up issues for that work.
* **Question:** What should the UX be after saving the selected collections to My Space?
  * Answered: navigate to My Space

## Screenshots

https://user-images.githubusercontent.com/2723066/136426301-18bfb318-bbd2-4fab-9316-edd003031828.mp4

