### PR TITLE
feat: Validate custom URL when adding a link to a collection

### DIFF
--- a/cypress/integration/sites-and-applications.spec.js
+++ b/cypress/integration/sites-and-applications.spec.js
@@ -192,21 +192,20 @@ describe('Sites and Applications', () => {
           .then(($el) => $el[0].checkValidity())
           .should('be.false')
 
-        /*
-          // TODO - URL validation
         cy.findByLabelText('URL')
           .type('not a URL')
           .then(($el) => $el[0].checkValidity())
           .should('be.false')
-          */
 
         cy.findByLabelText('URL')
           .clear()
-          .type('http://www.example.com')
+          .type('http://www.example.com{enter}')
+          .blur()
           .then(($el) => $el[0].checkValidity())
           .should('be.true')
 
-        cy.findByRole('option', { name: 'http://www.example.com' }).click()
+        cy.findByLabelText('URL').should('have.value', 'http://www.example.com')
+
         cy.findByRole('button', { name: 'Add site' }).click()
       })
 

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -100,13 +100,11 @@ describe('CustomCollection component', () => {
     expect(urlInput).toBeInTheDocument()
     expect(urlInput).toBeInvalid()
 
-    /*
-    // TODO - add URL validation back
     userEvent.type(urlInput, 'example')
     expect(urlInput).toBeInvalid()
+    userEvent.clear(urlInput)
     userEvent.type(urlInput, 'http://www.example.com')
     expect(urlInput).toBeValid()
-    */
   })
 
   it('entering a new custom URL opens the modal', () => {

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -294,6 +294,62 @@ describe('CustomCollection component', () => {
     )
   })
 
+  it('can enter an invalid link, and then select an existing link', () => {
+    const mockAddLink = jest.fn()
+
+    const mockLinks = [
+      {
+        id: 'testBookmark1',
+        url: 'http://www.example.com/1',
+        label: 'Test Bookmark 1',
+      },
+      {
+        id: 'testBookmark2',
+        url: 'http://www.example.com/2',
+        label: 'Test Bookmark 2',
+      },
+      {
+        id: 'testBookmark3',
+        url: 'http://www.example.com/3',
+        label: 'Test Bookmark 3',
+      },
+    ]
+
+    render(
+      <CustomCollection
+        {...exampleCollection}
+        bookmarkOptions={mockLinks}
+        handleRemoveBookmark={jest.fn()}
+        handleAddBookmark={mockAddLink}
+        handleRemoveCollection={jest.fn()}
+        handleEditCollection={jest.fn()}
+      />
+    )
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: '+ Add link',
+      })
+    )
+
+    const urlInput = screen.getByLabelText('URL')
+    userEvent.type(urlInput, 'example{enter}')
+    expect(urlInput).toBeInvalid()
+
+    userEvent.click(
+      screen.getByRole('button', { name: 'Toggle the dropdown list' })
+    )
+    userEvent.click(screen.getByRole('option', { name: 'Test Bookmark 2' }))
+    expect(urlInput).toBeValid()
+
+    userEvent.click(screen.getByRole('button', { name: 'Add site' }))
+
+    expect(mockAddLink).toHaveBeenCalledWith(
+      'http://www.example.com/2',
+      'Test Bookmark 2'
+    )
+  })
+
   it('renders the settings dropdown menu', () => {
     render(
       <CustomCollection

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -19,6 +19,9 @@ import DropdownMenu from 'components/DropdownMenu/DropdownMenu'
 import RemoveCustomCollectionModal from 'components/modals/RemoveCustomCollectionModal'
 import { useCloseWhenClickedOutside } from 'hooks/useCloseWhenClickedOutside'
 
+// Not an ideal way to validate URLs but this will work for now
+const VALID_URL_REGEX = /^(ftp|http|https):\/\/[^ "]+$/
+
 type PropTypes = {
   id: string
   title?: string
@@ -66,7 +69,6 @@ const CustomCollection = ({
       urlInputValue.current = ''
       setIsAdding(false)
     } else {
-      // TODO - validate URl here
       // Adding a custom link
       addCustomLinkModal.current?.toggleModal(undefined, true)
     }
@@ -106,6 +108,16 @@ const CustomCollection = ({
         urlOptions[urlOptions.length - 1] = { value, label: value }
       }
     }
+
+    if (VALID_URL_REGEX.test(value)) {
+      // valid
+      e.target.setCustomValidity('')
+    } else {
+      // invalid
+      e.target.setCustomValidity(
+        'Please enter a valid URL, starting with http:// or https://'
+      )
+    }
   }
 
   const addLinkForm = (
@@ -123,7 +135,6 @@ const CustomCollection = ({
             onChange={handleSelectChange}
             inputProps={{
               required: true,
-              // type: 'url', // TODO - handle conditional validation
               onChange: handleInputChange,
               placeholder: 'Type or paste link...',
             }}

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -96,11 +96,13 @@ const CustomCollection = ({
     const existingLink = value && selectedExistingLink(value)
     const enteredCustomLink = urlOptions.length !== bookmarkOptions.length
 
-    // console.log('select option', value)
-
     if (existingLink && enteredCustomLink) {
       // Remove entered custom link
       urlOptions.pop()
+      // Reset input validation
+      const inputEl = document.getElementById('bookmarkUrl') as HTMLInputElement
+      inputEl?.setCustomValidity('')
+      inputEl?.reportValidity()
     }
 
     urlInputValue.current = value || ''
@@ -108,8 +110,6 @@ const CustomCollection = ({
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-
-    // console.log('INPUT CHANGE', value)
 
     if (value) {
       if (urlOptions.length === bookmarkOptions.length) {

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -93,11 +93,23 @@ const CustomCollection = ({
     )
 
   const handleSelectChange = (value: string | undefined) => {
+    const existingLink = value && selectedExistingLink(value)
+    const enteredCustomLink = urlOptions.length !== bookmarkOptions.length
+
+    // console.log('select option', value)
+
+    if (existingLink && enteredCustomLink) {
+      // Remove entered custom link
+      urlOptions.pop()
+    }
+
     urlInputValue.current = value || ''
   }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
+
+    // console.log('INPUT CHANGE', value)
 
     if (value) {
       if (urlOptions.length === bookmarkOptions.length) {


### PR DESCRIPTION
## Description 

This PR adds native form validation to the Add Link input, to verify that when a user is entering a custom link they provide a valid, complete URL. Since this is an initial implementation of this feature, it just uses a regex to verify the input. We may want to use a more robust method in the future since using regex to validate URL strings is usually not recommended.

Fixes #270 

## Review Notes

- Go to My Space and click "+ Add link" under a collection
- Try entering a non-URL into the input (i.e., www.example.com). You should see an error message and be prevented from adding the link.
- Verify you can enter a valid URL into the input (i.e., http://www.example.com) and proceed.
- Verify you can also still select an existing CMS link and add it to the collection.

![image](https://user-images.githubusercontent.com/2723066/139491073-050bf0b5-0d2d-4e6a-b5e0-91bea757a750.png)
