### PR TITLE
ci: Adding AWS Actions

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -19,6 +19,7 @@ jobs:
       run : |
         echo $RELEASE_VERSION
         echo ${{ env.RELEASE_VERSION }}
+        echo ${{ github.ref }}
     # - name: Configure AWS credentials
     #   uses: aws-actions/configure-aws-credentials@v1
     #   with:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Get tag
-      run: echo "RELEASE_VERSION=${GITHUB_REF#REFS/*/}" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: test
       run : |
         echo $RELEASE_VERSION
-        echo ${{ env.RELEASE_VERSION:10 }}
+        echo ${{ env.RELEASE_VERSION }}
     # - name: Configure AWS credentials
     #   uses: aws-actions/configure-aws-credentials@v1
     #   with:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -1,6 +1,12 @@
+# on:
+#   release:
+#     types: [published]
+
 on:
-  release:
-    types: [published]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build-and-push:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -1,0 +1,54 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get tag
+      run: echo "RELEASE_VERSION=${GITHUB_REF#REFS/*/}" >> $GITHUB_ENV
+    - name: test
+      run : |
+        echo $RELEASE_VERSION
+        echo ${{ env.RELEASE_VERSION }}
+    # - name: Configure AWS credentials
+    #   uses: aws-actions/configure-aws-credentials@v1
+    #   with:
+    #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    #     aws-region: us-west-2
+
+    # - name: Login to Amazon ECR
+    #   id: login-ecr
+    #   uses: aws-actions/amazon-ecr-login@v1
+
+    # - name: Build, tag, and push image to Amazon ECR
+    #   id: build-image
+    #   env:
+    #     ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+    #     ECR_REPOSITORY: portal-client
+    #     IMAGE_TAG: ${{ github.sha }}
+    #     C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
+    #     C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
+    #   run: |
+    #     docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+    #     docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+    #     echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+    # - name: Fill in the new image ID in the Amazon ECS task definition
+    #   id: task-def
+    #   uses: aws-actions/amazon-ecs-render-task-definition@v1
+    #   with:
+    #     task-definition: task-definition.json
+    #     container-name: my-container
+    #     image: ${{ steps.build-image.outputs.image }}
+
+    # - name: Deploy Amazon ECS task definition
+    #   uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+    #   with:
+    #     task-definition: ${{ steps.task-def.outputs.task-definition }}
+    #     service: my-service
+    #     cluster: my-cluster
+    #     wait-for-service-stability: true

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -1,4 +1,4 @@
-name: Docker Stuff
+name: Docker Build Main
 
 on:
   push:
@@ -52,7 +52,7 @@ jobs:
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: portal-client
-        cluster: app-my-webapp-dev
+        cluster: app-portal-client-dev
         wait-for-service-stability: true
 
     - name: Build, tag, and push image to C1 Artifactory

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -18,7 +18,7 @@ jobs:
     - name: test
       run : |
         echo $RELEASE_VERSION
-        echo ${{ env.RELEASE_VERSION }}
+        echo ${{ env.RELEASE_VERSION:10 }}
     # - name: Configure AWS credentials
     #   uses: aws-actions/configure-aws-credentials@v1
     #   with:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -15,14 +15,13 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v
-1
+      uses: aws-actions/amazon-ecr-login@v1
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -35,6 +34,10 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         docker logout $ECR_REGISTRY
+
+    - name: Download task definition
+      run: |
+        aws ecs describe-task-definition --task-definition portal-client --query taskDefinition > dev-task-definition.json
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def
@@ -59,6 +62,7 @@ jobs:
         C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
         C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
       run: |
+        docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
         docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .
         docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG"

--- a/.github/workflows/prototype-aws-ecr.yml
+++ b/.github/workflows/prototype-aws-ecr.yml
@@ -1,4 +1,4 @@
-name: Docker Stuff
+name: Docker Build Alpha
 
 on:
   push:

--- a/.github/workflows/prototype-aws-ecr.yml
+++ b/.github/workflows/prototype-aws-ecr.yml
@@ -16,14 +16,13 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-access-key-id: ${{ secrets.GHA_ECR_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.GHA_ECR_AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v
-1
+      uses: aws-actions/amazon-ecr-login@v1
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
@@ -36,6 +35,10 @@ jobs:
         docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
         echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         docker logout $ECR_REGISTRY
+
+    - name: Download task definition
+      run: |
+        aws ecs describe-task-definition --task-definition portal-client-prototype --query taskDefinition > prototype-task-definition.json
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def

--- a/.github/workflows/prototype-aws-ecr.yml
+++ b/.github/workflows/prototype-aws-ecr.yml
@@ -2,7 +2,8 @@ name: Docker Stuff
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'release-2.0.0-alpha.*'
 
 jobs:
   build-and-push-aws:
@@ -40,7 +41,7 @@ jobs:
       id: task-def
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
-        task-definition: dev-task-definition.json
+        task-definition: prototype-task-definition.json
         container-name: portal-client
         image: ${{ steps.build-image.outputs.image }}
 
@@ -49,17 +50,5 @@ jobs:
       with:
         task-definition: ${{ steps.task-def.outputs.task-definition }}
         service: portal-client
-        cluster: app-my-webapp-dev
+        cluster: app-portal-client-prototype
         wait-for-service-stability: true
-
-    - name: Build, tag, and push image to C1 Artifactory
-      id: build-image
-      env:
-        IMAGE_TAG: ${{ env.RELEASE_VERSION }}
-        C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
-        C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
-      run: |
-        docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .
-        docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
-        echo "::set-output name=image::$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG"
-        docker logout $C1_REGISTRY


### PR DESCRIPTION
## Description 

`dev-aws-ecr.yml` will run when merged to main branch. It will get the tag. Log into ECR. Build the image, tag the image based on the git tag and push the image to the Elastic Container Registry in our Dev AWS Account. It will then download the task definition for the dev stack, update it with the image created in the prior step, then update the service with the new image, deploying it. It will then upload the image to C1 Artifactory instance in dev.

`prototype-aws-ecr.yml` is similar to `dev-aws-ecr.yml` but rather than running on merge to main, it will run when a tag of `release-2.0.0-alpha.*` is created. It will not upload to C1 Artifactory. The workflow is otherwise the same in build and deployment deploying to the prototype stack.

Fixes #308 

## Review Notes
