### PR TITLE
ci: use github.sha rather than RELEASE_VERSION when merging to main branch

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -30,7 +30,7 @@ jobs:
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         ECR_REPOSITORY: portal-client
-        IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+        IMAGE_TAG: ${{ github.sha }}
 
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
@@ -61,7 +61,7 @@ jobs:
     - name: Build, tag, and push image to C1 Artifactory
       id: build-c1-image
       env:
-        IMAGE_TAG: ${{ env.RELEASE_VERSION }}
+        IMAGE_TAG: ${{ github.sha }}
         C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
         C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
       run: |

--- a/.github/workflows/prototype-aws-ecr.yml
+++ b/.github/workflows/prototype-aws-ecr.yml
@@ -3,7 +3,7 @@ name: Docker Build Alpha
 on:
   push:
     tags:
-      - 'release-2.0.0-alpha.*'
+      - '2.0.0-alpha.*'
 
 jobs:
   build-and-push-aws:


### PR DESCRIPTION
## Description 

When deploying to main, we want to use the git sha, rather than `/main`. For the prototype, we don't want a tag to have `release-` as a part of the name. This does that.
