### PR TITLE
ci: Defining the correct task definitiion for dev

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Download task definition
       run: |
-        aws ecs describe-task-definition --task-definition portal-client --query taskDefinition > dev-task-definition.json
+        aws ecs describe-task-definition --task-definition portal-client-dev --query taskDefinition > dev-task-definition.json
 
     - name: Fill in the new image ID in the Amazon ECS task definition
       id: task-def


### PR DESCRIPTION
## Description 

It used to be called `portal-client` but it's now called `portal-client-dev`. This fixes that.