### PR TITLE
ci: tell actions to use the correct container name.

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -47,7 +47,7 @@ jobs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: dev-task-definition.json
-        container-name: portal-client
+        container-name: portal-client-dev
         image: ${{ steps.build-aws-image.outputs.image }}
 
     - name: Deploy Amazon ECS task definition

--- a/.github/workflows/prototype-aws-ecr.yml
+++ b/.github/workflows/prototype-aws-ecr.yml
@@ -48,7 +48,7 @@ jobs:
       uses: aws-actions/amazon-ecs-render-task-definition@v1
       with:
         task-definition: prototype-task-definition.json
-        container-name: portal-client
+        container-name: portal-client-prototype
         image: ${{ steps.build-aws-image.outputs.image }}
 
     - name: Deploy Amazon ECS task definition


### PR DESCRIPTION
## Description 

The container name is actually `portal-client-dev` and `portal-client-prototype`. I tried to change the name in the console and it won't allow it. I think it's created upon creation of the cluster. So I need to update the action to use the properly named container name.
