### PR TITLE
ci: Making package files owned by everyone to allow renovatebot to automerge.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,10 @@
 
 # Github settings
 .github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth
+
+# CODEOWNERS prevent renovate automerge since it will automatically ask for review
+# See documentation for more details: https://docs.renovatebot.com/automerge-configuration/
+# Solution: make files used by renovate owned by everyone
+
+**/*/package.json
+**/*/yarn.lock


### PR DESCRIPTION
## Description 

Renovatebot won't automerge because of `CODEOWNERS`, but thanks to a fellow Trussel, and this [link](https://github.com/renovatebot/renovate/issues/6473#issuecomment-855543240), this might do what we want which is make the package files owned by everyone...which says it should allow renovatebot to automerge.

Fixes #

## Review Notes
