### PR TITLE
ci(docker): Reduce size of Docker production image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .next
+.keystone
 .dockerignore
 node_modules
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,16 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 RUN yarn build
 
+# Install only production deps this time
+RUN yarn install --production --ignore-scripts --prefer-offline
+
 # Production image, copy all the files and run next
-FROM builder AS runner
+FROM node:14.18.1-slim AS runner
+
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apt-get update \
+  && apt-get -y install openssl libc6
+
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
## Description 

* Only install production dependencies after building NextJS app
* Use node-slim for final image with deps installed for Prisma
* Ignore `.keystone` directory

## Review Notes
