### PR TITLE
chore: Add Mallory & Noah as temporary codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything
-* @suzubara @abbyoung @esacteksab
+* @suzubara @abbyoung @esacteksab @noahfirth @malworks
 
 # Github settings
 .github/settings.yml @suzubara @abbyoung @esacteksab @noahfirth


### PR DESCRIPTION
## Description 

Adding @noahfirth and @malworks as codeowners while other engineers are out on vacation so we can merge UI work without being blocked.
