### PR TITLE
ci: try and fix c1 build error

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -54,7 +54,10 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
         C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
         C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
+        CERT: ${{ secrets.SAML_CERT }}
+
       run: |
+        echo $CERT > saml.pem
         sudo sh scripts/add-dod-cas.sh
         docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
         docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
## Description 

The build process now needs this secret, adding it to the C1 step. I think this will just be the first iteration in getting to push to C1 artifactory. 

Fixes https://github.com/USSF-ORBIT/ussf-portal-client/runs/4369985932?check_suite_focus=true

