### PR TITLE
ci: C1 doesn't have the Dockerfile COPY step, so we need to be more explicit here

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -57,7 +57,7 @@ jobs:
         CERT: ${{ secrets.SAML_CERT }}
 
       run: |
-        echo $CERT > saml.pem
+        echo $CERT > /usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt
         sudo sh scripts/add-dod-cas.sh
         docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
         docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
## Description 

Building for AWS ECR is done _inside_ a Docker container. _This_ step is done inside an Ubuntu runner on Github Actions. So we need to be more explicit for the path of this cert. This does that.

