### PR TITLE
ci: sudo so we can access /usr/local/share/ca-certificates

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -57,7 +57,7 @@ jobs:
         CERT: ${{ secrets.SAML_CERT }}
 
       run: |
-        echo $CERT > /usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt
+        sudo echo $CERT > /usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt
         sudo sh scripts/add-dod-cas.sh
         docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
         docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
## Description 

Permission denied in the job. This should fix it.

Fixes https://github.com/USSF-ORBIT/ussf-portal-client/runs/4374027106?check_suite_focus=true
