### PR TITLE
ci: Give Docker the cert chain for Artifactory in Dev

### DIFF
--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -55,9 +55,12 @@ jobs:
         C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
         C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
         CERT: ${{ secrets.SAML_CERT }}
+        ART_CHAIN: ${{ secrets.C1_ARTIFACTORY_CHAIN }}
 
       run: |
         echo $CERT > saml.pem
+        sudo mkdir -p /etc/docker/certs.d/$C1_REGISTRY
+        echo $ART_CHAIN > /etc/docker/certs.d/$C1_REGISTRY/ca.crt
         sudo sh scripts/add-dod-cas.sh
         docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
         docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .


### PR DESCRIPTION
## Description 

This repo's actions still continue to fail to talk to artifactory though prototype successfully talks to artifactory with a copy/paste of the action yaml file. All of that to say, this _should_ make Docker aware of the cert chain for artifactory and hopefully appease it.

Fixes https://github.com/USSF-ORBIT/ussf-portal-client/runs/4387505248?check_suite_focus=true
