### PR TITLE
ci: Make C1 GHA task it's own job

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -1,0 +1,28 @@
+name: Docker Build Main Push C1 Artifactory
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-push-aws:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2
+
+    - name: Build, tag, and push image to C1 Artifactory
+      id: build-c1-image
+      env:
+        IMAGE_TAG: ${{ github.sha }}
+        C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
+        C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
+        CERT: ${{ secrets.SAML_CERT }}
+
+      run: |
+        echo $CERT > saml.pem
+        sudo sh scripts/add-dod-cas.sh
+        docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
+        docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .
+        docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
+        echo "::set-output name=image::$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG"
+        docker logout $C1_REGISTRY

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -1,4 +1,4 @@
-name: Docker Build Main
+name: Docker Build Main Push AWS Dev
 
 on:
   push:
@@ -48,22 +48,4 @@ jobs:
       run: |
         ./scripts/deploy-dev-aws.sh
 
-    - name: Build, tag, and push image to C1 Artifactory
-      id: build-c1-image
-      env:
-        IMAGE_TAG: ${{ github.sha }}
-        C1_REGISTRY: ${{ secrets.C1_REGISTRY }}
-        C1_REPOSITORY: ${{ secrets.C1_REPOSITORY }}
-        CERT: ${{ secrets.SAML_CERT }}
-        ART_CHAIN: ${{ secrets.C1_ARTIFACTORY_CHAIN }}
 
-      run: |
-        echo $CERT > saml.pem
-        sudo mkdir -p /etc/docker/certs.d/$C1_REGISTRY
-        echo $ART_CHAIN > /etc/docker/certs.d/$C1_REGISTRY/ca.crt
-        sudo sh scripts/add-dod-cas.sh
-        docker login -u portal -p ${{ secrets.C1_ARTIFACTORY_TOKEN }} $C1_REGISTRY
-        docker build -t $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG .
-        docker push $C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG
-        echo "::set-output name=image::$C1_REGISTRY/$C1_REPOSITORY:$IMAGE_TAG"
-        docker logout $C1_REGISTRY


### PR DESCRIPTION
## Description 

[This](https://github.com/USSF-ORBIT/ussf-portal-prototype/runs/4372801956?check_suite_focus=true) works. [This](https://github.com/USSF-ORBIT/ussf-portal-client/runs/4395484444?check_suite_focus=true) continues to fail. At this point, the only difference between the two jobs [1](https://github.com/USSF-ORBIT/ussf-portal-prototype/blob/main/.github/workflows/dev-aws-ecr.yml) [2](https://github.com/USSF-ORBIT/ussf-portal-prototype/blob/barry-test-aws-actions/.github/workflows/dev-aws-ecr.yml) is that the prototype repo doesn't have all the AWS steps prior to C1. So this is me making a unique job for C1 to see if somehow the previous steps are messing things up somehow. 
