### PR TITLE
chore: Production readiness

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,7 @@ const securityHeaders = [
 
 module.exports = withKeystone(
   withBundleAnalyzer({
+    reactStrictMode: true,
     // swcMinify: true,
     async headers() {
       return [

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -6,6 +6,7 @@ import {
   AuthenticationError,
   ApolloError,
 } from 'apollo-server-micro'
+import { ApolloServerPluginLandingPageDisabled } from 'apollo-server-core'
 import type { PageConfig } from 'next'
 
 import { typeDefs } from '../../schema'
@@ -23,6 +24,7 @@ export const config: PageConfig = {
 export const apolloServer = new ApolloServer({
   typeDefs,
   resolvers,
+  plugins: [ApolloServerPluginLandingPageDisabled()],
   context: async ({ req, res }) => {
     const session = await getSession(req, res)
 


### PR DESCRIPTION
## Description 

- Disabled Apollo Server landing page `/api/graphql`
- Turn on React strict mode

Fixes #367 
Fixes #446 

## Review Notes

Tests should pass
You shouldn't be able to access the Apollo Server landing page at `/api/graphql`