### PR TITLE
ci: Enable dependency dashboard, turn on presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,16 @@
 {
-  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
+  "extends": [
+    "config:base",
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard",
+    "group:allApollographql",
+    "group:fortawesome",
+    "group:reactMonorepo",
+    "group:storybookMonorepo",
+    "npm:unpublishSafe",
+    "packages:eslint",
+    "packages:jsUnitTest"
+  ],
   "packageRules": [
     {
       "rebaseWhen": "behind-base-branch",


### PR DESCRIPTION
## Description 

I made some adjustments to Renovate config:
- Turn on the [dependency dashboard](https://docs.renovatebot.com/key-concepts/dashboard/)
- Add presets to group related package updates together
- Added preset to safeguard against npm packages being unpublished