### PR TITLE
feat: News page [sc-27]

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,5 @@
 const path = require('path')
+
 module.exports = {
   stories: ['../**/*.stories.mdx', '../**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
@@ -9,6 +10,7 @@ module.exports = {
     'storybook-addon-next-router',
     'storybook-addon-apollo-client',
   ],
+  staticDirs: ['../public'],
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.

--- a/e2e/cypress/integration/mvp.spec.js
+++ b/e2e/cypress/integration/mvp.spec.js
@@ -2,8 +2,6 @@ import logging from '../plugins/logging'
 describe('The MVP site', () => {
   describe('logged in pages', () => {
     before(() => {
-      Cypress.Cookies.debug(true)
-
       cy.loginTestIDP()
     })
 

--- a/e2e/cypress/integration/news.spec.js
+++ b/e2e/cypress/integration/news.spec.js
@@ -1,0 +1,27 @@
+import logging from '../plugins/logging'
+
+describe('News and Announcements', () => {
+  before(() => {
+    cy.loginTestIDP()
+    cy.visit('/joinbeta')
+    cy.intercept(
+      'https://www.spaceforce.mil/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1060&max=12'
+    ).as('getNewsRSS')
+  })
+
+  beforeEach(() => {
+    cy.preserveLoginCookies()
+    cy.preserveBetaCookie()
+    cy.visit('/')
+    cy.injectAxe()
+  })
+
+  it('can visit the News page', () => {
+    cy.findByRole('link', { name: 'News' }).click()
+    cy.url().should('eq', Cypress.config().baseUrl + '/news')
+    cy.findByRole('heading', { level: 1 }).contains('News')
+    cy.wait(['@getNewsRSS'])
+    cy.findAllByRole('article').should('exist')
+    cy.checkA11y(null, null, logging, { skipFailures: true })
+  })
+})

--- a/next.config.js
+++ b/next.config.js
@@ -72,6 +72,17 @@ module.exports = withKeystone(
             destination: '/beta/leavebeta',
           },
           {
+            source: '/news',
+            has: [
+              {
+                type: 'cookie',
+                key: 'betaOptIn',
+                value: 'true',
+              },
+            ],
+            destination: '/beta/news',
+          },
+          {
             source: '/',
             has: [
               {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "next build",
     "build:analyze": "ANALYZE=true yarn build",
     "start": "node -r ./server-preload.js node_modules/.bin/next start",
-    "storybook": "start-storybook -p 6006 -s ./public",
+    "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook",
     "format": "prettier --write .",
     "lint": "tsc --noEmit && eslint .",
@@ -117,6 +117,12 @@
     "trim": "0.0.3",
     "graphql": "16.0.1"
   },
+  "browserslist": [
+    "> 2%",
+    "last 2 versions",
+    "IE 11",
+    "not dead"
+  ],
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [
       "prettier --write",

--- a/src/__tests__/pages/beta/news.test.tsx
+++ b/src/__tests__/pages/beta/news.test.tsx
@@ -77,7 +77,7 @@ describe('News page', () => {
 
       expect(
         await screen.findByRole('heading', { level: 2 })
-      ).toHaveTextContent('Latest News')
+      ).toHaveTextContent('Latest news')
       expect(await screen.findAllByRole('article')).toHaveLength(10)
     })
 

--- a/src/__tests__/pages/beta/news.test.tsx
+++ b/src/__tests__/pages/beta/news.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react'
+import { useRouter } from 'next/router'
+import axios from 'axios'
+
+import { renderWithAuth } from '../../../testHelpers'
+
+import mockRssFeed from '__mocks__/news-rss'
+import News from 'pages/beta/news'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    route: '',
+    pathname: '',
+    query: '',
+    asPath: '',
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}))
+
+const mockedUseRouter = useRouter as jest.Mock
+
+mockedUseRouter.mockReturnValue({
+  route: '',
+  pathname: '',
+  query: '',
+  asPath: '',
+  push: mockPush,
+  replace: mockReplace,
+})
+
+describe('News page', () => {
+  describe('without a user', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+
+      mockedAxios.get.mockImplementationOnce(() => {
+        return Promise.reject()
+      })
+
+      renderWithAuth(<News />, { user: null })
+    })
+
+    it('renders the loader while fetching the user and does not fetch RSS items', () => {
+      expect(screen.getByText('Content is loading...')).toBeInTheDocument()
+      expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+    })
+
+    it('redirects to the login page if not logged in', async () => {
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/login')
+      })
+    })
+  })
+
+  describe('when logged in', () => {
+    beforeEach(() => {
+      mockedAxios.get.mockClear()
+    })
+
+    it('renders the page title and RSS items', async () => {
+      mockedAxios.get.mockImplementation(() => {
+        return Promise.resolve({ data: mockRssFeed })
+      })
+
+      renderWithAuth(<News />)
+
+      expect(
+        await screen.findByRole('heading', { level: 2 })
+      ).toHaveTextContent('Latest News')
+      expect(await screen.findAllByRole('article')).toHaveLength(10)
+    })
+
+    describe('if the RSS fetch fails', () => {
+      it('logs the error', async () => {
+        const consoleSpy = jest.spyOn(console, 'error')
+
+        mockedAxios.get.mockRejectedValueOnce(new Error('Error fetching RSS'))
+
+        renderWithAuth(<News />)
+
+        waitFor(() =>
+          expect(consoleSpy).toHaveBeenCalledWith('Error fetching RSS feed')
+        )
+      })
+    })
+  })
+})

--- a/src/components/BreadcrumbNav/BreadcrumbNav.stories.tsx
+++ b/src/components/BreadcrumbNav/BreadcrumbNav.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import type { Meta } from '@storybook/react'
+
+import BreadcrumbNav from './BreadcrumbNav'
+
+export default {
+  title: 'Components/BreadcrumbNav',
+  component: BreadcrumbNav,
+  decorators: [
+    (Story) => (
+      <div className="sfds">
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta
+
+export const NewsAndAnnouncements = () => (
+  <BreadcrumbNav
+    navItems={[
+      { path: '/', label: 'Service portal home' },
+      { path: '/news', label: 'News & Announcements', current: true },
+    ]}
+  />
+)
+
+export const SearchResults = () => (
+  <BreadcrumbNav
+    navItems={[
+      { path: '/', label: 'Service portal home' },
+      { path: '/search', label: 'Search' },
+      { path: '#', label: '“PT Test”', current: true },
+    ]}
+  />
+)

--- a/src/components/BreadcrumbNav/BreadcrumbNav.test.tsx
+++ b/src/components/BreadcrumbNav/BreadcrumbNav.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import BreadcrumbNav from './BreadcrumbNav'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    route: '',
+    pathname: '',
+    query: '',
+    asPath: '',
+  }),
+}))
+
+const navItems = [
+  { path: '/', label: 'Service portal home' },
+  { path: '/news', label: 'News & Announcements', current: true },
+]
+
+describe('BreadcrumbNav component', () => {
+  beforeEach(() => {
+    render(<BreadcrumbNav navItems={navItems} />)
+  })
+
+  it('renders links for the non-current nav items', () => {
+    const links = screen.getAllByRole('link')
+
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', navItems[0].path)
+    expect(links[0]).toHaveTextContent(navItems[0].label)
+  })
+
+  it('renders the current item as static text', () => {
+    expect(screen.getByText('News & Announcements')).toBeInstanceOf(
+      HTMLLIElement
+    )
+    expect(screen.getByText('News & Announcements')).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+  })
+})

--- a/src/components/BreadcrumbNav/BreadcrumbNav.tsx
+++ b/src/components/BreadcrumbNav/BreadcrumbNav.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import {
+  BreadcrumbBar,
+  Breadcrumb,
+  BreadcrumbLink,
+} from '@trussworks/react-uswds'
+
+import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
+
+type PropTypes = {
+  navItems: {
+    path: string
+    label: React.ReactNode
+    current?: boolean
+  }[]
+}
+
+const BreadcrumbNav = ({ navItems }: PropTypes) => (
+  <BreadcrumbBar>
+    {navItems.map((i) =>
+      i.current ? (
+        <Breadcrumb key={`nav_${i.path}`} current>
+          {i.label}
+        </Breadcrumb>
+      ) : (
+        <Breadcrumb key={`nav_${i.path}`}>
+          <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href={i.path}>
+            {i.label}
+          </BreadcrumbLink>
+        </Breadcrumb>
+      )
+    )}
+  </BreadcrumbBar>
+)
+
+export default BreadcrumbNav

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -41,6 +41,10 @@
       border-radius: 6px;
     }
 
+    .usa-nav__primary > .usa-nav__primary-item + .usa-nav__primary-item {
+      margin-left: units(2);
+    }
+
     .usa-nav__primary > .usa-nav__primary-item > a {
       color: $theme-white;
       font-weight: normal;
@@ -51,10 +55,20 @@
         color: $theme-black;
         border-radius: 6px;
       }
+
+      &.usa-current {
+        background: $theme-aurora-lightest;
+        color: $theme-black;
+        border-radius: 6px;
+
+        &:after {
+          content: none;
+        }
+      }
     }
   }
 
   :global(.usa-nav__primary) .logoutButton {
-    margin-left: units(4);
+    margin-left: units(2);
   }
 }

--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -29,7 +29,7 @@ describe('Header component', () => {
     expect(
       screen.getByRole('img', { name: 'United States Space Force Logo' })
     ).toHaveAttribute('alt', 'United States Space Force Logo')
-    expect(screen.getAllByRole('link')).toHaveLength(2)
+    expect(screen.getAllByRole('link')).toHaveLength(3)
   })
 
   it('can toggle navigation on smaller screen sizes', () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import {
 import styles from './Header.module.scss'
 
 import Logo from 'components/Logo/Logo'
+import NavLink from 'components/util/NavLink/NavLink'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 import { useAuthContext } from 'stores/authContext'
 import { useAnalytics } from 'stores/analyticsContext'
@@ -34,6 +35,9 @@ const Header = () => {
       rel="noreferrer noopener">
       <span>About this portal</span>
     </LinkTo>,
+    <NavLink key="nav_news" href="/news">
+      News
+    </NavLink>,
     <Button
       secondary
       className={styles.logoutButton}

--- a/src/components/NewsListItem/NewsListItem.module.scss
+++ b/src/components/NewsListItem/NewsListItem.module.scss
@@ -16,7 +16,7 @@ a.articleLink {
   }
 
   > * {
-    display: inline-block;
+    display: inline;
   }
 
   h4 {
@@ -32,6 +32,12 @@ a.articleLink {
   img {
     width: 100%;
     display: block;
+    height: 200px;
+    object-fit: cover;
+
+    @include at-media('tablet') {
+      height: 360px;
+    }
   }
 }
 
@@ -40,5 +46,7 @@ a.articleLink {
 }
 
 .articleExcerpt {
+  font-size: 18px;
+  line-height: 1.4;
   margin: units('105') 0 units(3);
 }

--- a/src/components/NewsListItem/NewsListItem.module.scss
+++ b/src/components/NewsListItem/NewsListItem.module.scss
@@ -1,0 +1,44 @@
+@import 'styles/uswdsDependencies';
+@import 'styles/sfds/sfdsDependencies';
+
+.articleLink,
+a.articleLink {
+  display: block;
+  text-decoration: none;
+  color: $theme-black;
+
+  &:hover {
+    text-decoration: underline;
+
+    > * {
+      text-decoration: underline;
+    }
+  }
+
+  > * {
+    display: inline-block;
+  }
+
+  h4 {
+    margin: 0;
+  }
+}
+
+.articleImage {
+  border: 1px solid #c4c4c4;
+  border-radius: 6px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    display: block;
+  }
+}
+
+.articleImage + .articleLink {
+  margin-top: units(2);
+}
+
+.articleExcerpt {
+  margin: units('105') 0 units(3);
+}

--- a/src/components/NewsListItem/NewsListItem.module.scss
+++ b/src/components/NewsListItem/NewsListItem.module.scss
@@ -1,6 +1,12 @@
 @import 'styles/uswdsDependencies';
 @import 'styles/sfds/sfdsDependencies';
 
+.NewsListItem {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .articleLink,
 a.articleLink {
   display: block;
@@ -49,4 +55,21 @@ a.articleLink {
   font-size: 18px;
   line-height: 1.4;
   margin: units('105') 0 units(3);
+  text-align: right;
+  flex-grow: 1;
+
+  .articleExcerptTruncate {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    word-break: none;
+    overflow: hidden;
+    hyphens: auto;
+    text-overflow: ellipsis;
+    text-align: left;
+  }
+}
+
+.articleTag {
+  align-self: flex-start;
 }

--- a/src/components/NewsListItem/NewsListItem.stories.tsx
+++ b/src/components/NewsListItem/NewsListItem.stories.tsx
@@ -16,11 +16,12 @@ export default {
 } as Meta
 
 const mockRSSArticle = {
-  title: 'DAF COVID-19 Statistics - Feb. 8, 2022',
+  id: 'testArticle',
+  title: 'Newest missile warning satellite accepted for operations',
   sourceLink:
     'https://www.spaceforce.mil/News/Article/2903050/daf-covid-19-statistics-feb-8-2022/',
-  description: `Below are current Coronavirus Disease 2019 statistics for Department of the Air Force personnel:`,
-  publishDate: '08 Feb 2022',
+  description: `Space Operations Command has accepted Space Based Geosynchronous Infrared Satellite 5 as operationally capable and has presented it to United States Space Command for operational use.`,
+  publishDate: '04 Feb 2022',
   thumbnailSrc:
     'https://media.defense.gov/2021/Dec/07/2002921422/670/394/0/211207-F-GO452-0001.JPG',
   source: 'RSS',
@@ -28,3 +29,7 @@ const mockRSSArticle = {
 }
 
 export const RSSArticle = () => <NewsListItem article={mockRSSArticle} />
+
+export const RSSArticleNoImage = () => (
+  <NewsListItem article={{ ...mockRSSArticle, thumbnailSrc: '' }} />
+)

--- a/src/components/NewsListItem/NewsListItem.stories.tsx
+++ b/src/components/NewsListItem/NewsListItem.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import type { Meta } from '@storybook/react'
+
+import NewsListItem from './NewsListItem'
+
+export default {
+  title: 'Components/NewsListItem',
+  component: NewsListItem,
+  decorators: [
+    (Story) => (
+      <div className="sfds">
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta
+
+const mockRSSArticle = {
+  title: 'DAF COVID-19 Statistics - Feb. 8, 2022',
+  sourceLink:
+    'https://www.spaceforce.mil/News/Article/2903050/daf-covid-19-statistics-feb-8-2022/',
+  description: `Below are current Coronavirus Disease 2019 statistics for Department of the Air Force personnel:`,
+  publishDate: '08 Feb 2022',
+  thumbnailSrc:
+    'https://media.defense.gov/2021/Dec/07/2002921422/670/394/0/211207-F-GO452-0001.JPG',
+  source: 'RSS',
+  sourceName: 'SPACEFORCE.mil',
+}
+
+export const RSSArticle = () => <NewsListItem article={mockRSSArticle} />

--- a/src/components/NewsListItem/NewsListItem.test.tsx
+++ b/src/components/NewsListItem/NewsListItem.test.tsx
@@ -29,7 +29,7 @@ describe('NewsListItem component', () => {
     })
 
     it('renders the article contents', () => {
-      expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
         testArticle.title
       )
       expect(
@@ -53,7 +53,7 @@ describe('NewsListItem component', () => {
         })
       ).toHaveAttribute('href', testArticle.sourceLink)
 
-      expect(screen.getByText(testArticle.description)).toBeInTheDocument()
+      expect(screen.getByText(/This is a test article/i)).toBeInTheDocument()
       expect(screen.getByText(testArticle.sourceName)).toBeInTheDocument()
     })
   })
@@ -64,7 +64,7 @@ describe('NewsListItem component', () => {
     })
 
     it('renders the article contents with no image', () => {
-      expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
         testArticle.title
       )
       expect(
@@ -85,7 +85,7 @@ describe('NewsListItem component', () => {
         })
       ).toHaveAttribute('href', testArticle.sourceLink)
 
-      expect(screen.getByText(testArticle.description)).toBeInTheDocument()
+      expect(screen.getByText(/This is a test article/i)).toBeInTheDocument()
       expect(screen.getByText(testArticle.sourceName)).toBeInTheDocument()
     })
   })

--- a/src/components/NewsListItem/NewsListItem.test.tsx
+++ b/src/components/NewsListItem/NewsListItem.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import NewsListItem from './NewsListItem'
+
+const testArticle = {
+  id: 'testArticle123',
+  title: 'Test Article Headline',
+  sourceLink: 'http://www.example.com',
+  description: 'This is a test article',
+  publishDate: 'Feb 08, 2022',
+  thumbnailSrc: 'https://via.placeholder.com/150',
+  sourceName: 'Example.com',
+  source: 'RSS',
+}
+
+const testArticleNoImage = {
+  ...testArticle,
+  thumbnailSrc: '',
+}
+
+describe('NewsListItem component', () => {
+  describe('with a complete article', () => {
+    beforeEach(() => {
+      render(<NewsListItem article={testArticle} />)
+    })
+
+    it('renders the article contents', () => {
+      expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(
+        testArticle.title
+      )
+      expect(
+        screen.getByText(`${testArticle.publishDate} //`)
+      ).toBeInTheDocument()
+
+      expect(screen.getByRole('img')).toHaveAttribute(
+        'src',
+        testArticle.thumbnailSrc
+      )
+
+      expect(
+        screen.getByRole('link', {
+          name: `${testArticle.title}`,
+        })
+      ).toHaveAttribute('href', testArticle.sourceLink)
+
+      expect(
+        screen.getByRole('link', {
+          name: `${testArticle.publishDate} // ${testArticle.title}`,
+        })
+      ).toHaveAttribute('href', testArticle.sourceLink)
+
+      expect(screen.getByText(testArticle.description)).toBeInTheDocument()
+      expect(screen.getByText(testArticle.sourceName)).toBeInTheDocument()
+    })
+  })
+
+  describe('with no image', () => {
+    beforeEach(() => {
+      render(<NewsListItem article={testArticleNoImage} />)
+    })
+
+    it('renders the article contents with no image', () => {
+      expect(screen.getByRole('heading', { level: 4 })).toHaveTextContent(
+        testArticle.title
+      )
+      expect(
+        screen.getByText(`${testArticle.publishDate} //`)
+      ).toBeInTheDocument()
+
+      expect(screen.queryByRole('img')).not.toBeInTheDocument()
+
+      expect(
+        screen.queryByRole('link', {
+          name: `${testArticle.title}`,
+        })
+      ).not.toBeInTheDocument()
+
+      expect(
+        screen.getByRole('link', {
+          name: `${testArticle.publishDate} // ${testArticle.title}`,
+        })
+      ).toHaveAttribute('href', testArticle.sourceLink)
+
+      expect(screen.getByText(testArticle.description)).toBeInTheDocument()
+      expect(screen.getByText(testArticle.sourceName)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/NewsListItem/NewsListItem.tsx
+++ b/src/components/NewsListItem/NewsListItem.tsx
@@ -7,9 +7,10 @@ import styles from './NewsListItem.module.scss'
 import colors from 'styles/sfds/colors.module.scss'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 
-type NewsListItem = {
+export type NewsListItemArticle = {
+  id: string
   thumbnailSrc?: string
-  publishDate: string
+  publishDate?: string
   title: string
   description: string
   source: string
@@ -17,14 +18,13 @@ type NewsListItem = {
   sourceLink: string
 }
 
-const NewsListItem = ({ article }: { article: NewsListItem }) => {
+const NewsListItem = ({ article }: { article: NewsListItemArticle }) => {
   const {
     title,
     sourceLink,
     description,
     publishDate,
     thumbnailSrc,
-    source,
     sourceName,
   } = article
 

--- a/src/components/NewsListItem/NewsListItem.tsx
+++ b/src/components/NewsListItem/NewsListItem.tsx
@@ -64,7 +64,7 @@ const NewsListItem = ({ article }: { article: NewsListItemArticle }) => {
           )}
           target="_blank"
           rel="noreferrer noopener">
-          continue reading on SpaceForce.mil
+          continue reading
         </LinkTo>
         )
       </p>

--- a/src/components/NewsListItem/NewsListItem.tsx
+++ b/src/components/NewsListItem/NewsListItem.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import classnames from 'classnames'
+import { Tag } from '@trussworks/react-uswds'
+
+import styles from './NewsListItem.module.scss'
+
+import colors from 'styles/sfds/colors.module.scss'
+import LinkTo from 'components/util/LinkTo/LinkTo'
+
+type NewsListItem = {
+  thumbnailSrc?: string
+  publishDate: string
+  title: string
+  description: string
+  source: string
+  sourceName: string
+  sourceLink: string
+}
+
+const NewsListItem = ({ article }: { article: NewsListItem }) => {
+  const {
+    title,
+    sourceLink,
+    description,
+    publishDate,
+    thumbnailSrc,
+    source,
+    sourceName,
+  } = article
+
+  return (
+    <article>
+      {thumbnailSrc && (
+        <div className={styles.articleImage}>
+          <LinkTo href={sourceLink} target="_blank" rel="noreferrer noopener">
+            <img src={thumbnailSrc} alt={title} />
+          </LinkTo>
+        </div>
+      )}
+
+      <LinkTo
+        href={sourceLink}
+        className={classnames(styles.articleLink, 'usa-link--external')}
+        target="_blank"
+        rel="noreferrer noopener">
+        {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
+        <small>{publishDate} //</small>
+        &nbsp;
+        <h4>{title}</h4>
+      </LinkTo>
+
+      <p className={styles.articleExcerpt}>{description}</p>
+
+      <Tag background={colors['theme-mars-base']}>{sourceName}</Tag>
+    </article>
+  )
+}
+
+export default NewsListItem

--- a/src/components/NewsListItem/NewsListItem.tsx
+++ b/src/components/NewsListItem/NewsListItem.tsx
@@ -29,7 +29,7 @@ const NewsListItem = ({ article }: { article: NewsListItemArticle }) => {
   } = article
 
   return (
-    <article>
+    <article className={styles.NewsListItem}>
       {thumbnailSrc && (
         <div className={styles.articleImage}>
           <LinkTo href={sourceLink} target="_blank" rel="noreferrer noopener">
@@ -46,12 +46,32 @@ const NewsListItem = ({ article }: { article: NewsListItemArticle }) => {
         {/* eslint-disable-next-line react/jsx-no-comment-textnodes */}
         <small>{publishDate} //</small>
         &nbsp;
-        <h4>{title}</h4>
+        <h3>
+          <strong>{title}</strong>
+        </h3>
       </LinkTo>
 
-      <p className={styles.articleExcerpt}>{description}</p>
+      <p className={styles.articleExcerpt}>
+        <span className={styles.articleExcerptTruncate}>
+          {description}&hellip;
+        </span>
+        (
+        <LinkTo
+          href={sourceLink}
+          className={classnames(
+            styles.articleExcerptLink,
+            'usa-link--external'
+          )}
+          target="_blank"
+          rel="noreferrer noopener">
+          continue reading on SpaceForce.mil
+        </LinkTo>
+        )
+      </p>
 
-      <Tag background={colors['theme-mars-base']}>{sourceName}</Tag>
+      <Tag className={styles.articleTag} background={colors['theme-mars-base']}>
+        {sourceName}
+      </Tag>
     </article>
   )
 }

--- a/src/components/PageHeader/PageHeader.module.scss
+++ b/src/components/PageHeader/PageHeader.module.scss
@@ -23,6 +23,11 @@ $hero-image: url('/assets/images/hero.jpeg');
     background-color: $black;
   }
 
+  h1 {
+    text-transform: uppercase;
+    margin-bottom: 0;
+  }
+
   a,
   :global(.usa-link) {
     color: $theme-aurora-base;

--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
+import {
+  BreadcrumbBar,
+  Breadcrumb,
+  BreadcrumbLink,
+} from '@trussworks/react-uswds'
 import type { Meta } from '@storybook/react'
 
 import PageHeader from './PageHeader'
 
 import PersonalData from 'components/PersonalData/PersonalData'
+import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
 
 export default {
   title: 'Layout/PageHeader',
@@ -26,5 +32,21 @@ export const PortalHome = () => (
 export const PortalHomeDisabledSearch = () => (
   <PageHeader disableSearch>
     <PersonalData />
+  </PageHeader>
+)
+
+export const NewsAndAnnouncements = () => (
+  <PageHeader disableSearch>
+    <div>
+      <h1>News &amp; Announcements</h1>
+      <BreadcrumbBar>
+        <Breadcrumb>
+          <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href="/">
+            Service portal home
+          </BreadcrumbLink>
+        </Breadcrumb>
+        <Breadcrumb current>News & Announcements</Breadcrumb>
+      </BreadcrumbBar>
+    </div>
   </PageHeader>
 )

--- a/src/components/util/NavLink/NavLink.tsx
+++ b/src/components/util/NavLink/NavLink.tsx
@@ -7,7 +7,7 @@ import { pathToRegexp } from 'path-to-regexp'
 import LinkTo from '../LinkTo/LinkTo'
 import type { PropTypes as LinkToProps } from '../LinkTo/LinkTo'
 
-type NavLinkProps = LinkToProps & {
+export type NavLinkProps = LinkToProps & {
   exact?: boolean
   activeClass?: string
 }

--- a/src/hooks/useRSSFeed.test.tsx
+++ b/src/hooks/useRSSFeed.test.tsx
@@ -20,6 +20,10 @@ mockedAxios.get.mockImplementation(() => {
 const MOCK_RSS_URL = 'MOCK_RSS_URL'
 
 describe('useRSSFeed hook', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockClear()
+  })
+
   it('returns the item state and a method for fetching items', () => {
     const { result } = renderHook(() => useRSSFeed(MOCK_RSS_URL))
 
@@ -45,6 +49,47 @@ describe('useRSSFeed hook', () => {
       date: 'Jul 23, 2021',
       image:
         'https://media.defense.gov/2021/May/19/2002809800/670/394/0/210519-F-GO452-0001.JPG',
+    })
+  })
+
+  describe('with an empty item', () => {
+    it('returns an empty article', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: `<?xml version="1.0" encoding="utf-8"?>\r\n<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cf="http://www.microsoft.com/schemas/rss/core/2005">\r\n <channel>
+    \r\n <title>United States Space Force News</title>\r\n
+    <link>https://www.spaceforce.mil</link>\r\n <description>United States Space Force News RSS Feed</description>\r\n
+    <language>en-us</language>\r\n <pubDate>Fri, 23 Jul 2021 15:29:00 GMT</pubDate>\r\n <lastBuildDate>Mon, 26 Jul 2021
+      14:05:50 GMT</lastBuildDate>\r\n
+    <atom:link
+      href="http://www.spaceforce.mil/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&amp;Site=1060&amp;max=10?ContentType=1&amp;Site=1060&amp;isdashboardselected=0&amp;max=10"
+      rel="self" type="application/rss+xml" />\r\n <item>\r\n <link></link>\r\n<description>This is an empty article</description>\r\n<pubDate></pubDate>\r\n<title></title>\r\n
+      \r\n <dc:creator>DoD News</dc:creator>\r\n <guid isPermaLink="false">https://www.spaceforce.mil/News/Article/2705653/senate-confirms-gina-ortiz-jones-to-be-air-force-under-secretary/</guid>\r\n
+      <enclosure url="https://media.defense.gov/2021/May/19/2002809800/670/394/0/210519-F-GO452-0001.JPG"
+        type="image/jpeg" />\r\n
+    </item>\r\n 
+  </channel>\r\n</rss>
+`,
+      })
+
+      const { result } = renderHook(() => useRSSFeed(MOCK_RSS_URL))
+
+      await waitFor(() => {
+        result.current.fetchItems()
+      })
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(MOCK_RSS_URL)
+
+      expect(result.current.items.length).toBe(1)
+      expect(result.current.items[0]).toMatchObject({
+        id: 'https://www.spaceforce.mil/News/Article/2705653/senate-confirms-gina-ortiz-jones-to-be-air-force-under-secretary/',
+        title: '',
+        link: '',
+        desc: 'This is an empty article',
+        date: '',
+        image:
+          'https://media.defense.gov/2021/May/19/2002809800/670/394/0/210519-F-GO452-0001.JPG',
+      })
     })
   })
 

--- a/src/hooks/useRSSFeed.test.tsx
+++ b/src/hooks/useRSSFeed.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { waitFor } from '@testing-library/react'
+import { renderHook } from '@testing-library/react-hooks'
+import axios from 'axios'
+
+import { useRSSFeed } from './useRSSFeed'
+
+import mockRssFeed from '__mocks__/news-rss'
+
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+mockedAxios.get.mockImplementation(() => {
+  return Promise.resolve({ data: mockRssFeed })
+})
+
+const MOCK_RSS_URL = 'MOCK_RSS_URL'
+
+describe('useRSSFeed hook', () => {
+  it('returns the item state and a method for fetching items', () => {
+    const { result } = renderHook(() => useRSSFeed(MOCK_RSS_URL))
+
+    expect(result.current.items).toEqual([])
+    expect(result.current.fetchItems).toBeTruthy()
+  })
+
+  it('fetching the items sets them in state', async () => {
+    const { result } = renderHook(() => useRSSFeed(MOCK_RSS_URL))
+
+    await waitFor(() => {
+      result.current.fetchItems()
+    })
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(MOCK_RSS_URL)
+
+    expect(result.current.items.length).toBe(10)
+    expect(result.current.items[0]).toMatchObject({
+      id: 'https://www.spaceforce.mil/News/Article/2705653/senate-confirms-gina-ortiz-jones-to-be-air-force-under-secretary/',
+      title: 'Senate confirms Gina Ortiz Jones to be Air Force Under Secretary',
+      link: 'https://www.spaceforce.mil/News/Article/2705653/senate-confirms-gina-ortiz-jones-to-be-air-force-under-secretary/',
+      desc: 'In explaining the basis for choosing Jones, the White House highlighted that she was commissioned through the Air Force ROTC program while a student at Boston University and “has spent her career working to protect U.S. economic and national security.”',
+      date: 'Jul 23, 2021',
+      image:
+        'https://media.defense.gov/2021/May/19/2002809800/670/394/0/210519-F-GO452-0001.JPG',
+    })
+  })
+
+  // TODO - error?
+})

--- a/src/hooks/useRSSFeed.tsx
+++ b/src/hooks/useRSSFeed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import axios from 'axios'
 
 export type RSSNewsItem = {
@@ -10,62 +10,67 @@ export type RSSNewsItem = {
   image?: string
 }
 
-export const useRSSFeed = (feedUrl: string) => {
+export const useRSSFeed = (
+  feedUrl: string
+): {
+  items: RSSNewsItem[]
+  fetchItems: () => void
+} => {
   const [items, setItems] = useState<RSSNewsItem[]>([])
 
-  // Fetch RSS items on mount
-  useEffect(() => {
-    const fetchItems = async () => {
-      try {
-        const response = await axios.get(feedUrl)
+  const fetchItems = async () => {
+    try {
+      const response = await axios.get(feedUrl)
 
-        // Process XML items
-        const xml = new window.DOMParser().parseFromString(
-          response.data,
-          'text/xml'
-        )
-        const items = xml.querySelectorAll('item')
+      // Process XML items
+      const xml = new window.DOMParser().parseFromString(
+        response.data,
+        'text/xml'
+      )
+      const items = xml.querySelectorAll('item')
 
-        // Process SpaceForce.mil news items
-        const newsItems: RSSNewsItem[] = []
-        items.forEach((el) => {
-          const id = el.querySelector('guid')?.textContent || ''
-          const title = el.querySelector('title')?.textContent || ''
-          const link = el.querySelector('link')?.textContent || ''
-          const image = el.querySelector('enclosure')?.getAttribute('url') || ''
+      // Process SpaceForce.mil news items
+      const newsItems: RSSNewsItem[] = []
+      items.forEach((el) => {
+        const id = el.querySelector('guid')?.textContent || ''
+        const title = el.querySelector('title')?.textContent || ''
+        const link = el.querySelector('link')?.textContent || ''
+        const image = el.querySelector('enclosure')?.getAttribute('url') || ''
 
-          // Truncate before the first <br /> tag
-          const desc =
-            el.querySelector('description')?.innerHTML.split('&lt;br')[0] || ''
+        // Truncate before the first <br /> tag
+        const desc =
+          el.querySelector('description')?.innerHTML.split('&lt;br')[0] || ''
 
-          // Formate date: MMM DD, YYYY
-          const date = el.querySelector('pubDate')?.textContent
-          const formattedDate =
-            (date &&
-              new Date(date).toLocaleString('en-US', {
-                day: '2-digit',
-                month: 'short',
-                year: 'numeric',
-              })) ||
-            ''
+        // Formate date: MMM DD, YYYY
+        const date = el.querySelector('pubDate')?.textContent
+        const formattedDate =
+          (date &&
+            new Date(date).toLocaleString('en-US', {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+            })) ||
+          ''
 
-          newsItems.push({
-            id,
-            title,
-            link,
-            desc,
-            date: formattedDate,
-            image,
-          })
+        newsItems.push({
+          id,
+          title,
+          link,
+          desc,
+          date: formattedDate,
+          image,
         })
+      })
 
-        setItems(newsItems)
-      } catch (e) {
-        console.error('Error fetching RSS feed', e)
-      }
+      setItems(newsItems)
+    } catch (e) {
+      // TODO - set error state for UI?
+      console.error('Error fetching RSS feed')
     }
-    fetchItems()
-  }, [])
+  }
 
-  return items
+  return {
+    items,
+    fetchItems,
+  }
 }

--- a/src/hooks/useRSSFeed.tsx
+++ b/src/hooks/useRSSFeed.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export type RSSNewsItem = {
+  id?: string
+  desc?: string
+  date?: string
+  link?: string
+  title?: string
+  image?: string
+}
+
+export const useRSSFeed = (feedUrl: string) => {
+  const [items, setItems] = useState<RSSNewsItem[]>([])
+
+  // Fetch RSS items on mount
+  useEffect(() => {
+    const fetchItems = async () => {
+      try {
+        const response = await axios.get(feedUrl)
+
+        // Process XML items
+        const xml = new window.DOMParser().parseFromString(
+          response.data,
+          'text/xml'
+        )
+        const items = xml.querySelectorAll('item')
+
+        // Process SpaceForce.mil news items
+        const newsItems: RSSNewsItem[] = []
+        items.forEach((el) => {
+          const id = el.querySelector('guid')?.textContent || ''
+          const title = el.querySelector('title')?.textContent || ''
+          const link = el.querySelector('link')?.textContent || ''
+          const image = el.querySelector('enclosure')?.getAttribute('url') || ''
+
+          // Truncate before the first <br /> tag
+          const desc =
+            el.querySelector('description')?.innerHTML.split('&lt;br')[0] || ''
+
+          // Formate date: MMM DD, YYYY
+          const date = el.querySelector('pubDate')?.textContent
+          const formattedDate =
+            (date &&
+              new Date(date).toLocaleString('en-US', {
+                day: '2-digit',
+                month: 'short',
+                year: 'numeric',
+              })) ||
+            ''
+
+          newsItems.push({
+            id,
+            title,
+            link,
+            desc,
+            date: formattedDate,
+            image,
+          })
+        })
+
+        setItems(newsItems)
+      } catch (e) {
+        console.error('Error fetching RSS feed', e)
+      }
+    }
+    fetchItems()
+  }, [])
+
+  return items
+}

--- a/src/layout/Beta/DefaultLayout/PageLayout.test.tsx
+++ b/src/layout/Beta/DefaultLayout/PageLayout.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+import PageLayout, { withPageLayout } from './PageLayout'
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    route: '',
+    pathname: '',
+    query: '',
+    asPath: '',
+  }),
+}))
+
+describe('PageLayout component', () => {
+  beforeEach(() => {
+    render(
+      <PageLayout header={<h1>Test Page</h1>}>
+        <h2>Beta Test Page</h2>
+      </PageLayout>
+    )
+  })
+
+  it('renders the header and children', () => {
+    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument()
+  })
+
+  it('renders a skip nav link', () => {
+    expect(
+      screen.getByRole('link', { name: 'Skip to main content' })
+    ).toHaveAttribute('href', '#main-content')
+
+    expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content')
+  })
+
+  it('renders common layout elements', () => {
+    expect(screen.getAllByRole('banner')).toHaveLength(2) // Gov banner & site header
+    expect(screen.getAllByRole('navigation')).toHaveLength(2) // header, page nav, footer
+  })
+})
+
+describe('withPageLayout HOC', () => {
+  it('renders children inside of the page layout', () => {
+    const TestPage = () => <div>My page</div>
+    render(withPageLayout(<h1>Test Page</h1>, <TestPage />))
+    expect(screen.getByText('My page')).toBeInTheDocument()
+  })
+})

--- a/src/layout/Beta/DefaultLayout/PageLayout.tsx
+++ b/src/layout/Beta/DefaultLayout/PageLayout.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { GovBanner, GridContainer } from '@trussworks/react-uswds'
+
+import styles from './DefaultLayout.module.scss'
+
+import BetaBanner from 'components/BetaBanner/BetaBanner'
+import Header from 'components/Header/Header'
+import PageHeader from 'components/PageHeader/PageHeader'
+import Footer from 'components/Footer/Footer'
+
+const PageLayout = ({
+  header,
+  children,
+}: {
+  header: React.ReactNode
+  children: React.ReactNode
+}) => {
+  return (
+    <>
+      <a className="usa-skipnav" href="#main-content">
+        Skip to main content
+      </a>
+      <div className={`${styles.siteContainer} sfds`}>
+        <GovBanner tld=".mil" />
+        <BetaBanner />
+        <Header />
+        <main id="main-content">
+          <PageHeader disableSearch>{header}</PageHeader>
+
+          <GridContainer containerSize="widescreen">
+            {/* PAGE CONTENT */}
+            {children}
+          </GridContainer>
+        </main>
+        <Footer />
+      </div>
+    </>
+  )
+}
+
+export default PageLayout
+
+export const withPageLayout = (
+  header: React.ReactNode,
+  page: React.ReactNode
+) => <PageLayout header={header}>{page}</PageLayout>

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -1,13 +1,39 @@
-import { withBetaLayout } from 'layout/Beta/DefaultLayout/DefaultLayout'
+import React from 'react'
+import {
+  BreadcrumbBar,
+  Breadcrumb,
+  BreadcrumbLink,
+} from '@trussworks/react-uswds'
+
+import PageLayout from 'layout/Beta/DefaultLayout/PageLayout'
+import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
 
 const News = () => {
   return (
     <div>
-      <h1>News</h1>
+      <h2>Latest News</h2>
+      <h3>The most recently publicly released Space Force news.</h3>
     </div>
   )
 }
 
 export default News
 
-News.getLayout = withBetaLayout
+News.getLayout = (page: React.ReactNode) => (
+  <PageLayout
+    header={
+      <div>
+        <h1>News &amp; Announcements</h1>
+        <BreadcrumbBar>
+          <Breadcrumb>
+            <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href="/">
+              Service portal home
+            </BreadcrumbLink>
+          </Breadcrumb>
+          <Breadcrumb current>News & Announcements</Breadcrumb>
+        </BreadcrumbBar>
+      </div>
+    }>
+    {page}
+  </PageLayout>
+)

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -9,6 +9,7 @@ import {
 import { withPageLayout } from 'layout/Beta/DefaultLayout/PageLayout'
 import Loader from 'components/Loader/Loader'
 import { useUser } from 'hooks/useUser'
+import LinkTo from 'components/util/LinkTo/LinkTo'
 import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
 import NewsListItem, {
   NewsListItemArticle,
@@ -68,6 +69,16 @@ const News = () => {
             </Grid>
           ))}
       </Grid>
+
+      <div style={{ textAlign: 'right' }}>
+        <LinkTo
+          href="https://www.spaceforce.mil/News"
+          target="_blank"
+          rel="noreferrer noopener"
+          className="usa-button">
+          Read more on SpaceForce.mil
+        </LinkTo>
+      </div>
     </div>
   )
 }

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -51,7 +51,7 @@ const News = () => {
     <Loader />
   ) : (
     <div>
-      <h2>Latest News</h2>
+      <h2>Latest news</h2>
       <h3>The most recently publicly released Space Force news.</h3>
 
       <Grid row gap={2}>
@@ -76,14 +76,14 @@ export default News
 News.getLayout = (page: React.ReactNode) =>
   withPageLayout(
     <div>
-      <h1>News &amp; Announcements</h1>
+      <h1>News</h1>
       <BreadcrumbBar>
         <Breadcrumb>
           <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href="/">
             Service portal home
           </BreadcrumbLink>
         </Breadcrumb>
-        <Breadcrumb current>News & Announcements</Breadcrumb>
+        <Breadcrumb current>News</Breadcrumb>
       </BreadcrumbBar>
     </div>,
     page

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -3,16 +3,59 @@ import {
   BreadcrumbBar,
   Breadcrumb,
   BreadcrumbLink,
+  Grid,
 } from '@trussworks/react-uswds'
 
 import PageLayout from 'layout/Beta/DefaultLayout/PageLayout'
 import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
+import NewsListItem, {
+  NewsListItemArticle,
+} from 'components/NewsListItem/NewsListItem'
+import { useRSSFeed, RSSNewsItem } from 'hooks/useRSSFeed'
+import styles from 'styles/pages/news.module.scss'
+
+const RSS_URL = `https://www.spaceforce.mil/DesktopModules/ArticleCS/RSS.ashx?ContentType=1&Site=1060&max=12`
+
+const validateNewsItems = (item: RSSNewsItem): boolean => {
+  return !!(item.id && item.desc && item.date && item.link && item.title)
+}
+
+const formatRssToArticle = (
+  item: Required<RSSNewsItem>
+): NewsListItemArticle => {
+  return {
+    id: item.id,
+    title: item.title,
+    sourceLink: item.link,
+    description: item.desc,
+    publishDate: item.date,
+    thumbnailSrc: item.image,
+    source: 'RSS',
+    sourceName: 'SPACEFORCE.mil',
+  }
+}
 
 const News = () => {
+  const newsItems = useRSSFeed(RSS_URL)
+
   return (
     <div>
       <h2>Latest News</h2>
       <h3>The most recently publicly released Space Force news.</h3>
+
+      <Grid row gap={2}>
+        {newsItems
+          .filter(validateNewsItems)
+          .map((item) => formatRssToArticle(item as Required<RSSNewsItem>))
+          .map((item, i) => (
+            <Grid
+              key={`newsItem_${i}_${item.id}`}
+              tablet={{ col: 6 }}
+              className={styles.newsItemContainer}>
+              <NewsListItem article={item} />
+            </Grid>
+          ))}
+      </Grid>
     </div>
   )
 }

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import {
   BreadcrumbBar,
   Breadcrumb,
@@ -6,7 +6,9 @@ import {
   Grid,
 } from '@trussworks/react-uswds'
 
-import PageLayout from 'layout/Beta/DefaultLayout/PageLayout'
+import { withPageLayout } from 'layout/Beta/DefaultLayout/PageLayout'
+import Loader from 'components/Loader/Loader'
+import { useUser } from 'hooks/useUser'
 import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
 import NewsListItem, {
   NewsListItemArticle,
@@ -36,15 +38,24 @@ const formatRssToArticle = (
 }
 
 const News = () => {
-  const newsItems = useRSSFeed(RSS_URL)
+  const { user } = useUser()
+  const { items, fetchItems } = useRSSFeed(RSS_URL)
 
-  return (
+  useEffect(() => {
+    if (user) {
+      fetchItems()
+    }
+  }, [user])
+
+  return !user ? (
+    <Loader />
+  ) : (
     <div>
       <h2>Latest News</h2>
       <h3>The most recently publicly released Space Force news.</h3>
 
       <Grid row gap={2}>
-        {newsItems
+        {items
           .filter(validateNewsItems)
           .map((item) => formatRssToArticle(item as Required<RSSNewsItem>))
           .map((item, i) => (
@@ -62,21 +73,18 @@ const News = () => {
 
 export default News
 
-News.getLayout = (page: React.ReactNode) => (
-  <PageLayout
-    header={
-      <div>
-        <h1>News &amp; Announcements</h1>
-        <BreadcrumbBar>
-          <Breadcrumb>
-            <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href="/">
-              Service portal home
-            </BreadcrumbLink>
-          </Breadcrumb>
-          <Breadcrumb current>News & Announcements</Breadcrumb>
-        </BreadcrumbBar>
-      </div>
-    }>
-    {page}
-  </PageLayout>
-)
+News.getLayout = (page: React.ReactNode) =>
+  withPageLayout(
+    <div>
+      <h1>News &amp; Announcements</h1>
+      <BreadcrumbBar>
+        <Breadcrumb>
+          <BreadcrumbLink<NavLinkProps> asCustom={NavLink} href="/">
+            Service portal home
+          </BreadcrumbLink>
+        </Breadcrumb>
+        <Breadcrumb current>News & Announcements</Breadcrumb>
+      </BreadcrumbBar>
+    </div>,
+    page
+  )

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -1,0 +1,13 @@
+import { withBetaLayout } from 'layout/Beta/DefaultLayout/DefaultLayout'
+
+const News = () => {
+  return (
+    <div>
+      <h1>News</h1>
+    </div>
+  )
+}
+
+export default News
+
+News.getLayout = withBetaLayout

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -70,13 +70,13 @@ const News = () => {
           ))}
       </Grid>
 
-      <div style={{ textAlign: 'right' }}>
+      <div style={{ textAlign: 'center' }}>
         <LinkTo
           href="https://www.spaceforce.mil/News"
           target="_blank"
           rel="noreferrer noopener"
           className="usa-button">
-          Read more on SpaceForce.mil
+          Read more news
         </LinkTo>
       </div>
     </div>

--- a/src/pages/beta/news.tsx
+++ b/src/pages/beta/news.tsx
@@ -51,9 +51,10 @@ const News = () => {
     <Loader />
   ) : (
     <div>
-      <h2>Latest news</h2>
-      <h3>The most recently publicly released Space Force news.</h3>
-
+      <div className={styles.pageTitle}>
+        <h2>Latest news</h2>
+        <h3>The most recently publicly released Space Force news.</h3>
+      </div>
       <Grid row gap={2}>
         {items
           .filter(validateNewsItems)

--- a/src/styles/pages/news.module.scss
+++ b/src/styles/pages/news.module.scss
@@ -1,9 +1,20 @@
 @import 'styles/uswdsDependencies';
 
-.newsItemContainer {
-  > article {
-    padding-bottom: units(6);
-    border-bottom: 1px solid #c4c4c4;
-    margin-bottom: units(3);
+.pageTitle {
+  margin-top: units(6);
+  margin-bottom: units(4);
+
+  h2 {
+    margin-bottom: 0;
   }
+
+  h2 + h3 {
+    margin-top: units('105');
+  }
+}
+
+.newsItemContainer {
+  padding-bottom: units(4);
+  border-bottom: 1px solid #c4c4c4;
+  margin-bottom: units(4);
 }

--- a/src/styles/pages/news.module.scss
+++ b/src/styles/pages/news.module.scss
@@ -1,0 +1,9 @@
+@import 'styles/uswdsDependencies';
+
+.newsItemContainer {
+  > article {
+    padding-bottom: units(6);
+    border-bottom: 1px solid #c4c4c4;
+    margin-bottom: units(3);
+  }
+}

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -1,5 +1,6 @@
 /** Space Force Design System **/
 /** ------------------------- **/
+@import 'styles/uswdsDependencies';
 
 // Sharp Sans
 @import '../fonts.scss';
@@ -333,5 +334,10 @@
 
   .usa-breadcrumb__link {
     text-decoration: underline;
+  }
+
+  /** Tags **/
+  .usa-tag {
+    padding: units('05') units(1);
   }
 }

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -115,7 +115,8 @@
     }
 
     p,
-    span {
+    span,
+    .usa-breadcrumb {
       color: $theme-cosmiclatte-lightest;
     }
 
@@ -124,6 +125,12 @@
       &:hover {
         color: $theme-aurora-lighter;
       }
+    }
+
+    .usa-breadcrumb__list-item:not(:last-child)::after {
+      background-color: $theme-cosmiclatte-lightest;
+      -webkit-mask: url('/vendor/img/usa-icons/navigate_next.svg') no-repeat
+        center/2ex 2ex;
     }
   }
 
@@ -317,5 +324,14 @@
   .usa-tooltip__body {
     background-color: $theme-spacebase-dark;
     padding: units(2);
+  }
+
+  /** Breadcrumbs **/
+  .usa-breadcrumb {
+    background-color: transparent;
+  }
+
+  .usa-breadcrumb__link {
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
## Description 

This PR adds a new page to `/news` which fetches and displays the 12 most recent articles from the SpaceForce.mil RSS feed. A link to the new page is in the header.

It also creates an alternative layout for beta pages that allows passing in a header node, instead of rendering the user's personal data.

New components in Storybook:
* `BreadcrumbNav`
* `NewsListItem`

Fixes #262 
Fixes sc-27

## Review Notes

Visit the News page by clicking on the link in the header navigation & verify it loads expected content.

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/2723066/153486765-5a4b0e43-e22a-4b59-a66a-4e1557b70eb5.png">

