### PR TITLE
ci: Getting first container in the task definition, not all containers.

### DIFF
--- a/scripts/deploy-dev-aws.sh
+++ b/scripts/deploy-dev-aws.sh
@@ -17,7 +17,7 @@ TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition portal-clie
                 memory: taskDefinition.memory
             }'> tmp-td.json)
 
-NEW_TASK_DEFINTION=$(jq -r --arg NEWIMAGE "$IMAGE" '.containerDefinitions[].image |= $NEWIMAGE' tmp-td.json > tmp-ntd.json)
+NEW_TASK_DEFINTION=$(jq -r --arg NEWIMAGE "$IMAGE" '.containerDefinitions[0].image |= $NEWIMAGE' tmp-td.json > tmp-ntd.json)
 NEW_TASK_INFO=$(aws ecs register-task-definition --cli-input-json file://tmp-ntd.json)
 NEW_REVISION=$(echo $NEW_TASK_INFO | jq '.taskDefinition.revision')
 aws ecs update-service --cluster app-portal-client-dev \


### PR DESCRIPTION
There are two container definitions, the first for `portal-client` the second for `aws-otel-collector`. This change updates the first, but leaves the second alone. This should fix the deploy which breaks as a result of updating both container definitions to use the newly created/uploaded portal-client docker image.