### PR TITLE
feat: Styling the Made By link

### DIFF
--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -22,10 +22,6 @@
       a {
         color: $theme-white;
         text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
       }
 
       > .grid-container {
@@ -35,6 +31,30 @@
 
     .usa-footer__nav {
       @include u-padding-y(2);
+
+      a {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
+  }
+}
+
+.madeByLink {
+  display: inline-block;
+  text-transform: uppercase;
+  background-color: $theme-ultraviolet-dark;
+  padding: units('05') units(1);
+  font-size: size('body', '3xs');
+  border-radius: 4px;
+
+  span {
+    line-height: 1;
+  }
+
+  &:hover {
+    text-decoration: none;
+    background-color: $theme-ultraviolet-darker;
   }
 }

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -10,9 +10,6 @@ import Logo from 'components/Logo/Logo'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 
 const Footer = () => {
-  // PROTOTYPE: Disabling this rule while this component is used for prototyping only!
-  /* eslint-disable jsx-a11y/anchor-is-valid */
-
   return (
     <USWDSFooter
       className={styles.footer}
@@ -23,6 +20,16 @@ const Footer = () => {
             <USWDSFooterLogo image={<Logo darkBg />} />
             <br />
             <small>©2021 All rights reserved, ORBIT Space Force</small>
+            <br />
+            <br />
+            <LinkTo
+              href="https://ussf-orbit.github.io/ussf-portal/"
+              target="_blank"
+              rel="noreferrer noopener"
+              className={styles.madeByLink}>
+              Made with ❤️ &nbsp; and{' '}
+              <span className="font-body-lg">&lsaquo;&rsaquo;</span> by ORBIT
+            </LinkTo>
           </div>
 
           <div className="grid-col-fill" />
@@ -32,14 +39,6 @@ const Footer = () => {
               <div className="grid-col">
                 <section className="usa-footer__primary-content usa-footer__primary-content--collapsible">
                   <ul className="usa-list usa-list--unstyled">
-                    <li className="usa-footer__secondary-link">
-                      <LinkTo
-                        href="https://ussf-orbit.github.io/ussf-portal/"
-                        target="_blank"
-                        rel="noreferrer noopener">
-                        About this portal
-                      </LinkTo>
-                    </li>
                     <li className="usa-footer__secondary-link">
                       <LinkTo
                         href="https://www.my.af.mil/afp/netstorage/faq/privacy_advisory.html"


### PR DESCRIPTION
# SC-368

## Proposed changes

Styles the "About this portal" link and moves underneath the USSF logo in the footer.

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

---

## Screenshots

![image](https://user-images.githubusercontent.com/2723066/158407318-64c356ca-0f3f-4b05-9463-53d29113b88d.png)
