### PR TITLE
chore: Remove Matomo & MariaDB from docker compose services stack

### DIFF
--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -42,38 +42,6 @@ services:
     volumes:
       - ./users.php:/var/www/simplesamlphp/config/authsources.php
 
-  mariadb:
-    image: docker.io/bitnami/mariadb:10.6
-    environment:
-      # ALLOW_EMPTY_PASSWORD is recommended only for development.
-      - ALLOW_EMPTY_PASSWORD=yes
-      - MARIADB_USER=bn_matomo
-      - MARIADB_DATABASE=bitnami_matomo
-      # Flag necessary for the database max allowed packet check
-      # https://matomo.org/faq/troubleshooting/faq_183/
-      - MARIADB_EXTRA_FLAGS=--max_allowed_packet=64MB
-    volumes:
-      - 'mariadb_data:/bitnami/mariadb'
-
-  matomo:
-    # https://github.com/bitnami/bitnami-docker-matomo
-    image: docker.io/bitnami/matomo:4
-    ports:
-      - '80:8080'
-      - '443:8443'
-    environment:
-      - MATOMO_DATABASE_HOST=mariadb
-      - MATOMO_DATABASE_PORT_NUMBER=3306
-      - MATOMO_DATABASE_USER=bn_matomo
-      - MATOMO_DATABASE_NAME=bitnami_matomo
-      # ALLOW_EMPTY_PASSWORD is recommended only for development.
-      - ALLOW_EMPTY_PASSWORD=yes
-      - MATOMO_WEBSITE_NAME=ussf-portal
-      - MATOMO_WEBSITE_HOST=http://localhost:3000
-    volumes:
-      - 'matomo_data:/bitnami/matomo'
-    depends_on:
-      - mariadb
 # CMS-specific services      
   keystone-db:
     container_name: keystone-db
@@ -91,7 +59,3 @@ services:
 volumes:
   portal_data:
   cms_data:
-  mariadb_data:
-    driver: local
-  matomo_data:
-    driver: local

--- a/docs/development.md
+++ b/docs/development.md
@@ -113,7 +113,7 @@ There are two separate Dockerfiles: `Dockerfile.dev`, which is used for running 
 
 ### Local Development with Docker
 
-You can spin up your Docker environment using Docker Compose. By running `yarn services:up`, it will use `docker-compose.services.yml` to create and run the services required for development.
+You can spin up your Docker environment using Docker Compose. By running `yarn services:up`, it will use `docker-compose.services.yml` to create and run the services required for development. This does _not_ include Matomo (our analytics platform) since the portal does not require it to run.
 
 Services include:
 
@@ -143,11 +143,7 @@ Services include:
 - Uses official Redis v6.0.0
 - Used to store session information
 
-5. Matomo & MariaDB
-
-- Manages platform analytics
-
-6. Postgres
+5. Postgres
 
 - Stores Keystone CMS data
 - Persists volume `cms_data`


### PR DESCRIPTION
## Proposed changes

This PR removes Matomo & its database (mariaDB) from the docker compose services stack, since it is not a dependency for running the application and doesn't need to be running during development.