### PR TITLE
feat: Add cancel button to Add Link flow

### DIFF
--- a/src/components/Bookmark/Bookmark.module.scss
+++ b/src/components/Bookmark/Bookmark.module.scss
@@ -6,6 +6,7 @@
   border: 1px solid color('base-light');
   border-radius: 5px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.1);
+  margin-bottom: 8px;
 
   display: flex;
 

--- a/src/components/CustomCollection/CustomCollection.module.scss
+++ b/src/components/CustomCollection/CustomCollection.module.scss
@@ -13,7 +13,7 @@
 }
 
 .addLink {
-  @include u-padding-x(2);
+  // @include u-padding-x(2);
   @include u-margin-top(2);
 
   :global(.usa-tooltip) {
@@ -29,6 +29,16 @@
       margin: 0;
       font-size: inherit;
     }
+  }
+}
+
+.addLinkComboBox {
+  input {
+    border: 1px solid #707c91;
+    box-sizing: border-box;
+    border-radius: 4px;
+    margin-top: 0;
+    font-family: 'Trebuchet MS';
   }
 }
 

--- a/src/components/CustomCollection/CustomCollection.module.scss
+++ b/src/components/CustomCollection/CustomCollection.module.scss
@@ -13,7 +13,6 @@
 }
 
 .addLink {
-  // @include u-padding-x(2);
   @include u-margin-top(2);
 
   :global(.usa-tooltip) {

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -250,6 +250,24 @@ describe('CustomCollection component', () => {
     expect(linkInput).toBeValid()
   })
 
+  it('cancels Add Link action and resets form', () => {
+    render(<CustomCollection {...exampleCollection} {...mockHandlers} />)
+
+    userEvent.click(screen.getByRole('button', { name: '+ Add link' }))
+    expect(screen.queryByLabelText('Select existing link')).toBeInTheDocument()
+
+    userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(
+      screen.getByRole('button', {
+        name: '+ Add link',
+      })
+    ).toBeInTheDocument()
+
+    expect(
+      screen.queryByLabelText('Select existing link')
+    ).not.toBeInTheDocument()
+  })
+
   it('can open the Add Custom Link modal', () => {
     const mockAddLink = jest.fn()
 

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -155,7 +155,7 @@ const CustomCollection = ({
               justifyContent: 'space-between',
               alignItems: 'center',
             }}>
-            <div>
+            <div style={{ width: '100%' }}>
               <Label htmlFor="bookmarkId" className="usa-sr-only">
                 Select existing link
               </Label>

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -181,7 +181,7 @@ const CustomCollection = ({
             )}
           </div>
 
-          <p className="usa-form__note">
+          <div className="usa-form__note">
             Don’t see what you need?
             <br />
             <div
@@ -200,7 +200,7 @@ const CustomCollection = ({
                 Cancel
               </Button>
             </div>
-          </p>
+          </div>
         </>
       ) : (
         <Button

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -184,9 +184,22 @@ const CustomCollection = ({
           <p className="usa-form__note">
             Don’t see what you need?
             <br />
-            <Button type="button" unstyled onClick={openCustomLinkModal}>
-              Add a custom link
-            </Button>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}>
+              <Button type="button" unstyled onClick={openCustomLinkModal}>
+                Add a custom link
+              </Button>
+              <Button
+                type="button"
+                unstyled
+                onClick={() => setIsAddingLink(false)}>
+                Cancel
+              </Button>
+            </div>
           </p>
         </>
       ) : (


### PR DESCRIPTION
# SC-418

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Adds cancel button for add link flow
- Updates styling for the CustomCollection and Bookmark components
---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [x] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [x] Checked responsiveness in mobile, tablet, and desktop
  - [x] Checked keyboard navigability
  - [x] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [x] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
![Screen Shot 2022-03-30 at 4 38 20 PM](https://user-images.githubusercontent.com/99674188/160935314-2760d814-f6f2-418b-9876-5017aa6b56e0.png)

