### PR TITLE
ci: Check for required env vars on startup

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -16,6 +16,7 @@ services:
       MONGO_URL: mongodb://mongo:27017
       MONGODB_DB: cypress-e2e
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
+      SESSION_DOMAIN: localhost
     stdin_open: true
     depends_on:
       - mongo

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,28 @@
    - [Install yarn](https://classic.yarnpkg.com/en/docs/install) if you do not already have it.
    - Type `yarn` or `yarn install` inside the project directory to install dependencies. You will need to do this once after cloning the project, and continuously if the dependencies in `package.json` change.
 
+### Environment variables
+
+These env variables are already set in `.envrc` and only need to be added to your local file if you want to override the defaults:
+
+- `SESSION_SECRET` - must be a string at least 32 chars, must be the same value set in the CMS application
+- `SESSION_DOMAIN` - the domain used for both the Portal app & CMS apps, must be the same value set in the CMS application
+- `MONGO_URL` - URL to the running MongoDB instance used for the Portal database
+- `MONGODB_DB` - Name of the MongoDB database used for the Portal database
+- `REDIS_URL` - URL to the running Redis instance, used by both CMS & Portal applications for storing sessions
+- `SAML_SSO_CALLBACK_URL` - URL to the Portal app login callback endpoint (`/api/auth/login`)
+- `SAML_IDP_METADATA_URL` - URL to the SAML IdP metadata
+- `SAML_ISSUER` - String identifying the Portal app SAML service provider
+- `MATOMO_URL` - URL to Matomo instance (this is not required for the app to run)
+- `MATOMO_SITE_ID` - ID of the Portal app in Matomo (this is not required for the app to run)
+
+#### Adding new environment variables
+
+> If you need to add a new environment variable used in the application, make sure to add it in the following places:
+> `.envrc` - Use this to document what the variable is, and set a default value for local development
+> `docs/development.md` (this file) - Add to the list above & document what the variable is
+> `startup/index.js` - Add to the `requireVars` array in this file in order to require this variable is set on startup of the app.
+
 ### Logging in
 
 This application uses SAML for its authentication mechanism. SAML relies on the existance of an Identity Provider (IdP). When running the app locally, there are two IdP options:

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,9 +51,10 @@ These env variables are already set in `.envrc` and only need to be added to you
 #### Adding new environment variables
 
 > If you need to add a new environment variable used in the application, make sure to add it in the following places:
-> `.envrc` - Use this to document what the variable is, and set a default value for local development
-> `docs/development.md` (this file) - Add to the list above & document what the variable is
-> `startup/index.js` - Add to the `requireVars` array in this file in order to require this variable is set on startup of the app.
+>
+> - `.envrc` - Use this to document what the variable is, and set a default value for local development
+> - `docs/development.md` (this file) - Add to the list above & document what the variable is
+> - `startup/index.js` - Add to the `requireVars` array in this file in order to require this variable is set on startup of the app.
 
 ### Logging in
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,7 +42,7 @@ These env variables are already set in `.envrc` and only need to be added to you
 - `MONGO_URL` - URL to the running MongoDB instance used for the Portal database
 - `MONGODB_DB` - Name of the MongoDB database used for the Portal database
 - `REDIS_URL` - URL to the running Redis instance, used by both CMS & Portal applications for storing sessions
-- `SAML_SSO_CALLBACK_URL` - URL to the Portal app login callback endpoint (`/api/auth/login`)
+- `SAML_SSO_CALLBACK_URL` - (_local dev only_) URL to the Portal app login callback endpoint
 - `SAML_IDP_METADATA_URL` - URL to the SAML IdP metadata
 - `SAML_ISSUER` - String identifying the Portal app SAML service provider
 - `MATOMO_URL` - URL to Matomo instance (this is not required for the app to run)

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "classnames": "2.3.1",
     "connect-redis": "6.1.3",
     "cookie-signature": "1.2.0",
+    "dotenv": "16.0.0",
     "graphql": "16.3.0",
     "micro": "9.3.4",
     "migrate": "1.8.0",

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -14,22 +14,11 @@ declare global {
   }
 }
 
-const host = process.env.MONGO_HOST || ''
-const user = process.env.MONGO_USER || ''
-const password = process.env.MONGO_PASSWORD || ''
-
-const RDS_TLS_CERT = process.env.RDS_TLS_CERT || 'rds-combined-ca-bundle.pem'
-
 // Connection string for DocumentDB
-const connectionString =
-  process.env.MONGO_URL ||
-  `mongodb://${user}:${password}@${host}/?tls=true&tlsCAFile=${RDS_TLS_CERT}&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
+const connectionString = process.env.MONGO_URL
 
 let client
 let clientPromise: Promise<typeof MongoClient>
-// if mongo_url is defined, use that for connection string instead
-// because it will only be defined locally
-// use check for connection string only
 
 if (process.env.NODE_ENV === 'development') {
   // In development mode, use a global variable so that the value

--- a/startup/index.js
+++ b/startup/index.js
@@ -12,11 +12,8 @@ const requireVars = [
   'REDIS_URL',
   'SAML_ISSUER',
   'SAML_IDP_METADATA_URL',
-  'SAML_SSO_CALLBACK_URL',
   'SESSION_SECRET',
   'SESSION_DOMAIN',
-  'MATOMO_URL',
-  'MATOMO_SITE_ID',
 ]
 
 function startup() {

--- a/startup/index.js
+++ b/startup/index.js
@@ -4,8 +4,32 @@
 const { initLogger } = require('./logging')
 const { runMigrations } = require('./migrate')
 const { initTracing } = require('./tracing')
+require('dotenv').config()
+
+const requireVars = [
+  'MONGO_URL',
+  'MONGODB_DB',
+  'REDIS_URL',
+  'SAML_ISSUER',
+  'SAML_IDP_METADATA_URL',
+  'SAML_SSO_CALLBACK_URL',
+  'SESSION_SECRET',
+  'SESSION_DOMAIN',
+  'MATOMO_URL',
+  'MATOMO_SITE_ID',
+]
+
 function startup() {
   initLogger()
+
+  requireVars.forEach((v) => {
+    if (process.env[`${v}`] === undefined) {
+      throw new Error(
+        `Startup Error: required environment variable ${v} is undefined`
+      )
+    }
+  })
+
   runMigrations()
   initTracing('AWSObservability')
 }

--- a/utils/mongodb.js
+++ b/utils/mongodb.js
@@ -3,16 +3,8 @@
 
 const { MongoClient } = require('mongodb')
 
-const host = process.env.MONGO_HOST || ''
-const user = process.env.MONGO_USER || ''
-const password = process.env.MONGO_PASSWORD || ''
-
-const RDS_TLS_CERT = process.env.RDS_TLS_CERT || 'rds-combined-ca-bundle.pem'
-
 // Connection string for DocumentDB
-const connectionString =
-  process.env.MONGO_URL ||
-  `mongodb://${user}:${password}@${host}/?tls=true&tlsCAFile=${RDS_TLS_CERT}&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
+const connectionString = process.env.MONGO_URL
 
 // Use the jest database if testing
 const dbName = process.env.NODE_ENV === 'test' ? 'jest' : process.env.MONGODB_DB

--- a/yarn.lock
+++ b/yarn.lock
@@ -8784,7 +8784,7 @@ dotenv@10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-dotenv@^16.0.0:
+dotenv@16.0.0, dotenv@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
   integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==


### PR DESCRIPTION
# SC-475

## Proposed changes

Adds a check to the startup script that throws an error if any required environment variables are undefined. Also updates documentation around setting/adding env vars.

## Reviewer notes

To test, edit your local environment to remove some required env vars and try starting the app in dev or production mode:
```
yarn dev
```
```
yarn build && yarn start
```

Instead of starting the app, it should throw an error that includes the name of the env var that is missing.

---

## Code review steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in subsequent PRs or stories

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed