### PR TITLE
ci: Fix the environment vars required for Mongo/DocDB

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -45,6 +45,10 @@ export CYPRESS_BASE_URL=http://localhost:3000
 ###################################
 export REDIS_URL=redis://localhost:6379
 
+export MONGO_HOST=''
+export MONGO_USER=''
+export MONGO_PASSWORD=''
+
 export MONGO_URL=mongodb://localhost:27017
 export MONGODB_DB=dev
 

--- a/docker-compose.client.yml
+++ b/docker-compose.client.yml
@@ -21,6 +21,10 @@ services:
       MONGO_URL: mongodb://mongo:27017
       MONGODB_DB: dev
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
+      SESSION_DOMAIN: localhost
+      MONGO_HOST: ''
+      MONGO_USER: ''
+      MONGO_PASSWORD: ''
     stdin_open: true
     depends_on:
       - mongo

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -17,6 +17,9 @@ services:
       MONGODB_DB: cypress-e2e
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
       SESSION_DOMAIN: localhost
+      MONGO_HOST: ''
+      MONGO_USER: ''
+      MONGO_PASSWORD: ''
     stdin_open: true
     depends_on:
       - mongo

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,8 @@ These env variables are already set in `.envrc` and only need to be added to you
 
 - `SESSION_SECRET` - must be a string at least 32 chars, must be the same value set in the CMS application
 - `SESSION_DOMAIN` - the domain used for both the Portal app & CMS apps, must be the same value set in the CMS application
-- `MONGO_URL` - URL to the running MongoDB instance used for the Portal database
+- `MONGO_URL` - URL to the running MongoDB instance used for the Portal database (only used in local dev)
+- `MONGO_HOST, MONGO_USER, MONGO_PASSWORD` - Only used in deployed environments for constructing the DocDB connection string. Need to be defined in other environments to start the app, but will be overridden by `MONGO_URL`.
 - `MONGODB_DB` - Name of the MongoDB database used for the Portal database
 - `REDIS_URL` - URL to the running Redis instance, used by both CMS & Portal applications for storing sessions
 - `SAML_SSO_CALLBACK_URL` - (_local dev only_) URL to the Portal app login callback endpoint

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -14,8 +14,16 @@ declare global {
   }
 }
 
+const host = process.env.MONGO_HOST || ''
+const user = process.env.MONGO_USER || ''
+const password = process.env.MONGO_PASSWORD || ''
+
+const RDS_TLS_CERT = process.env.RDS_TLS_CERT || 'rds-combined-ca-bundle.pem'
+
 // Connection string for DocumentDB
-const connectionString = process.env.MONGO_URL
+const connectionString =
+  process.env.MONGO_URL ||
+  `mongodb://${user}:${password}@${host}/?tls=true&tlsCAFile=${RDS_TLS_CERT}&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
 
 let client
 let clientPromise: Promise<typeof MongoClient>

--- a/startup/index.js
+++ b/startup/index.js
@@ -7,8 +7,9 @@ const { initTracing } = require('./tracing')
 require('dotenv').config()
 
 const requireVars = [
-  'MONGO_URL',
-  'MONGODB_DB',
+  'MONGO_HOST',
+  'MONGO_USER',
+  'MONGO_PASSWORD',
   'REDIS_URL',
   'SAML_ISSUER',
   'SAML_IDP_METADATA_URL',

--- a/utils/mongodb.js
+++ b/utils/mongodb.js
@@ -3,8 +3,16 @@
 
 const { MongoClient } = require('mongodb')
 
+const host = process.env.MONGO_HOST || ''
+const user = process.env.MONGO_USER || ''
+const password = process.env.MONGO_PASSWORD || ''
+
+const RDS_TLS_CERT = process.env.RDS_TLS_CERT || 'rds-combined-ca-bundle.pem'
+
 // Connection string for DocumentDB
-const connectionString = process.env.MONGO_URL
+const connectionString =
+  process.env.MONGO_URL ||
+  `mongodb://${user}:${password}@${host}/?tls=true&tlsCAFile=${RDS_TLS_CERT}&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`
 
 // Use the jest database if testing
 const dbName = process.env.NODE_ENV === 'test' ? 'jest' : process.env.MONGODB_DB


### PR DESCRIPTION
## Proposed changes

Fixes an issue introduced in https://github.com/USSF-ORBIT/ussf-portal-client/pull/618 where the environment variables required for connecting to DocDB were removed when they shouldn't have been.

The challenge here is that the connection string for Mongo/DocDB look quite different, and use different env vars. To get around this issue, I am requiring `MONGO_HOST, MONGO_USER, MONGO_PASSWORD` to be defined since those are what are used in deployed environments, but they can be explicitly set to empty strings for local development (which will use `MONGO_URL` instead, as long as its defined).

---

## Reviewer notes

Let's branch deploy to test this on AWS before merging.
