### PR TITLE
chore(release): 4.0.0-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.0.0-beta.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/3.1.0...4.0.0-beta.0) (2022-04-21)
+
 ## [3.1.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/3.0.0...3.1.0) (2022-04-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussf-portal",
-  "version": "3.1.0",
+  "version": "4.0.0-beta.0",
   "private": true,
   "engines": {
     "node": "14.19.1"


### PR DESCRIPTION
## [4.0.0-beta.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/3.1.0...4.0.0-beta.0) (2022-04-21)

_No changelog entries. This release is intended to test the CMS integration with the portal._