### PR TITLE
fix: URL descriptions are not being displayed when sorting sites and applications alphabetically

### DIFF
--- a/e2e/cypress/integration/sites-and-applications.spec.js
+++ b/e2e/cypress/integration/sites-and-applications.spec.js
@@ -48,6 +48,8 @@ describe('Sites and Applications', () => {
     cy.contains('Sort by type').should('be.enabled')
     cy.contains('Sort alphabetically').should('be.disabled')
     cy.contains('Application name')
+    // Check for a url description
+    cy.contains('Automated Computer Program Identification Number System')
     // cy.findAllByRole('row').should('have.length', 311)
 
     cy.contains('Sort by type').click()

--- a/src/operations/queries/getKeystoneBookmarks.tsx
+++ b/src/operations/queries/getKeystoneBookmarks.tsx
@@ -11,6 +11,7 @@ export const GET_KEYSTONE_BOOKMARKS = gql`
       id
       url
       label
+      description
     }
   }
 `


### PR DESCRIPTION
# SC-517

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- Fix missing URL descriptions on sites & applications page when sorting alphabetically

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->
- Log in and navigate to the Sites & Apps page
- Click on 'Sort alphabetically' and verify that you can see the description for each url in the list
## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->
- Pull down this branch and run locally, while also running the latest version of the CMS

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated E2E tests in Cypress

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

---
