### PR TITLE
chore(release): 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [4.1.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/4.0.0...4.1.0) (2022-05-17)
+
+
+### Features
+
+* Drag and drop support for links within a collection ([#630](https://github.com/USSF-ORBIT/ussf-portal-client/issues/630)) ([797526a](https://github.com/USSF-ORBIT/ussf-portal-client/commit/797526a69baeca9f6f086264c53540b91544925d))
+
 ## [4.0.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/4.0.0-beta.0...4.0.0) (2022-05-09)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ussf-portal",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "engines": {
     "node": "14.19.1"


### PR DESCRIPTION
## [4.1.0](https://github.com/USSF-ORBIT/ussf-portal-client/compare/4.0.0...4.1.0) (2022-05-17)


### Features

* Drag and drop support for links within a collection ([#630](https://github.com/USSF-ORBIT/ussf-portal-client/issues/630)) ([797526a](https://github.com/USSF-ORBIT/ussf-portal-client/commit/797526a69baeca9f6f086264c53540b91544925d))