### PR TITLE
ci: use the version defined in package.json, not hardcoded here

### DIFF
--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -10,10 +10,14 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     steps:
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+
       - name: Set up node
         uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # tag=v3
         with:
-          node-version: '14.19.1'
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
 
       - name: Check out repository
         uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # tag=v3

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -13,10 +13,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # tag=v3
 
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+
       - name: Set up node
         uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # tag=v3
         with:
-          node-version: '14.19.1'
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -12,10 +12,14 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # tag=v3
 
+      - name: Read Node.js version from package.json
+        run: echo ::set-output name=nodeVersion::$(node -p "require('./package.json').engines.node")
+        id: engines
+
       - name: Set up node
         uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # tag=v3
         with:
-          node-version: '14.19.1'
+          node-version: ${{ steps.engines.outputs.nodeVersion }}
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
When a PR like [this](https://github.com/USSF-ORBIT/ussf-portal-client/pull/651) exists, it doesn't update the github action. This is a known [issue](https://github.com/renovatebot/renovate/issues/7716) and per the workarounds in the [replies](https://github.com/renovatebot/renovate/issues/7716#issuecomment-843239292) this is an attempt to leverage this mechanism. 

The behavior today is to take the PR, manually push to the branch that renovate bot opens, thus tainting the PR so renovate will no longer manage it. This should take the burden off of us needing to update the github action with the proposed nodejs version.