### PR TITLE
chore: Fix Storybook deploy workflow by generating GQL types

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Storybook to Github Pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, sr-fix-storybook-deploy]
 
 jobs:
   deploy-storybook:
@@ -36,6 +36,9 @@ jobs:
       # The yarn cache is not node_modules
       - name: Install dependencies
         run: yarn --frozen-lockfile
+
+      - name: Generate GraphQL types
+        run: yarn generate
 
       - name: Deploy Storybook to Github page
         run: yarn storybook:deploy --ci --source-branch=main


### PR DESCRIPTION
## Proposed changes

The [storybook-deploy workflow](https://github.com/USSF-ORBIT/ussf-portal-client/actions/workflows/storybook-deploy.yml) has been failing on main, I believe because we need to run the graphql type generation script beforehand.
