### PR TITLE
test: update auth test to handle local and prod configuration

### DIFF
--- a/src/__tests__/pages/api/auth/[[...action]].test.ts
+++ b/src/__tests__/pages/api/auth/[[...action]].test.ts
@@ -108,8 +108,21 @@ describe('API / Auth handlers', () => {
         url: '/api/auth/logout',
         test: async ({ fetch }) => {
           const res = await fetch({ redirect: 'manual' })
-          expect(res.status).toBe(302)
-          expect(mockedAxios.post).toHaveBeenCalledWith('mock SLO request URL')
+          // TEMPORARY - DEVELOPMENT ONLY
+          // because our test IDP does not support SLO HTTP-POST bindings
+          if (
+            process.env.SAML_IDP_METADATA_URL ===
+              'http://idp:8080/simplesaml/saml2/idp/metadata.php' ||
+            process.env.SAML_IDP_METADATA_URL ===
+              'http://localhost:8080/simplesaml/saml2/idp/metadata.php'
+          ) {
+            expect(res.status).toBe(307)
+          } else {
+            expect(res.status).toBe(302)
+            expect(mockedAxios.post).toHaveBeenCalledWith(
+              'mock SLO request URL'
+            )
+          }
           expect(mockSession.destroy).toHaveBeenCalledTimes(1)
         },
       })


### PR DESCRIPTION
# SC-639

## Proposed changes

When running the tests a test `GET /api/auth/logout > logs out after logging in` would fail only locally. This PR updates the test to check the configuration the same way the production code does to adjust the expected response.

---

## Reviewer notes

This is my first PR for the ussf-portal-client project, so hopefully I haven't missed some part of the process.

## Setup

Run the unit tests locally, everything should pass.

```sh
yarn test
```

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - I marked this done, but technically there was no story but something I found setting up the project. But it didn't seem to deserve a whole other story.
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [X] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

none
