### PR TITLE
docs: update the branch pattern and link to Shortcut

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -219,13 +219,13 @@ yarn services:up
 
 ## Working on an issue
 
-To begin working on an issue, make sure you've assigned yourself to the issue in Github and marked it as "In Progress.".
+To begin working on an issue, make sure you've assigned yourself to the issue in [Shortcut](https://app.shortcut.com/orbit-truss) and marked it as "In Progress.".
 
 Once you have an issue to work on, create a new branch off `main` using the naming convention:
 
-`{issue #}-{short description}`
+`sc-{issue #}-{short description}`
 
-For example: `112-logo-component`
+For example: `sc-112-logo-component`
 
 We have a pre-commit hook set up using Husky to run on staged files only. This will run [Prettier](https://prettier.io/), [TypeScript compilation](https://www.typescriptlang.org/) and [eslint](https://eslint.org/) and fail on errors. For an optimal developer experience, it's recommended that you configure your editor to run linting & formatting inline.
 


### PR DESCRIPTION
# SC-639

## Proposed changes

Found that the docs still referred to the use of GitHub Issues and an old version of the branching pattern. This PR updates the docs accordingly.

---

## Reviewer notes

I discovered a test issue getting the project setup, see PR #688 for the fix for that which is part of this one story.

## Setup

See the modified developer readme.

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria, or will meet them in subsequent PRs or stories

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
