### PR TITLE
feat: ePubs search

### DIFF
--- a/src/__tests__/pages/search.test.tsx
+++ b/src/__tests__/pages/search.test.tsx
@@ -112,9 +112,10 @@ describe('Search page', () => {
       expect(
         await screen.findByRole('heading', { level: 2 })
       ).toHaveTextContent('There are 0 results for ‘’')
+
       expect(
-        await screen.findByRole('heading', { level: 3 })
-      ).toHaveTextContent('There are no results that match that query.')
+        screen.getAllByText('There are no results that match that query.')
+      ).toHaveLength(1)
     })
 
     it('renders no results if there were no matches for the query', async () => {
@@ -122,9 +123,10 @@ describe('Search page', () => {
       expect(
         await screen.findByRole('heading', { level: 2 })
       ).toHaveTextContent('There are 0 results for ‘nomatches’')
+
       expect(
-        await screen.findByRole('heading', { level: 3 })
-      ).toHaveTextContent('There are no results that match that query.')
+        screen.getAllByText('There are no results that match that query.')
+      ).toHaveLength(1)
     })
 
     it('renders the results if there were matches for the query', async () => {

--- a/src/components/EPubsCard/EPubsCard.module.scss
+++ b/src/components/EPubsCard/EPubsCard.module.scss
@@ -1,0 +1,25 @@
+@import 'styles/uswdsDependencies';
+
+.epubs {
+  border: 1px solid #929292;
+  border-radius: 8px;
+  padding: units(3);
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);
+  //   height: 20%;
+
+  > h3 {
+    margin: 0;
+  }
+
+  h3 + p {
+    margin-top: units('105');
+  }
+
+  p {
+    font-family: 'Sharp Sans';
+    font-size: 18px;
+    font-weight: 400;
+    line-height: 1.35;
+    text-overflow: wrap;
+  }
+}

--- a/src/components/EPubsCard/EPubsCard.module.scss
+++ b/src/components/EPubsCard/EPubsCard.module.scss
@@ -3,9 +3,8 @@
 .epubs {
   border: 1px solid #929292;
   border-radius: 8px;
-  padding: units(3);
+  padding: units(2);
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);
-  //   height: 20%;
 
   > h3 {
     margin: 0;

--- a/src/components/EPubsCard/EPubsCard.stories.tsx
+++ b/src/components/EPubsCard/EPubsCard.stories.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import type { Meta } from '@storybook/react'
+import EPubsCard from './EPubsCard'
+
+export default {
+  title: 'Components/EPubsCard',
+  component: EPubsCard,
+  decorators: [
+    (Story) => (
+      <div className="sfds">
+        <Story />
+      </div>
+    ),
+  ],
+} as Meta
+
+export const DefaultEPubsCard = () => <EPubsCard query="my test query" />

--- a/src/components/EPubsCard/EPubsCard.test.tsx
+++ b/src/components/EPubsCard/EPubsCard.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+
+import React from 'react'
+
+import EPubsCard from './EPubsCard'
+
+describe('EPubsCard component', () => {
+  it('renders the card', () => {
+    render(<EPubsCard query="test" />)
+
+    expect(screen.getAllByText('Looking for a form?')).toHaveLength(1)
+
+    const link = screen.getByRole('link', {
+      name: 'Search ePubs',
+    })
+
+    expect(link).toHaveAttribute(
+      'href',
+      'https://www.e-publishing.af.mil/Product-Index/#/?view=search&keyword=test&isObsolete=false&modID=449&tabID=131'
+    )
+    expect(link).toBeInstanceOf(HTMLAnchorElement)
+  })
+})

--- a/src/components/EPubsCard/EPubsCard.test.tsx
+++ b/src/components/EPubsCard/EPubsCard.test.tsx
@@ -20,7 +20,7 @@ describe('EPubsCard component', () => {
 
     expect(link).toHaveAttribute(
       'href',
-      'https://www.e-publishing.af.mil/Product-Index/#/?view=search&keyword=test&isObsolete=false&modID=449&tabID=131'
+      'https://search.usa.gov/search?affiliate=afpw_epubs&query=test'
     )
     expect(link).toBeInstanceOf(HTMLAnchorElement)
   })

--- a/src/components/EPubsCard/EPubsCard.tsx
+++ b/src/components/EPubsCard/EPubsCard.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import styles from './EPubsCard.module.scss'
+import LinkTo from 'components/util/LinkTo/LinkTo'
+
+type PropTypes = {
+  query: string
+}
+
+const EPubsCard = ({ query }: PropTypes) => {
+  const ePubsSearch = `https://www.e-publishing.af.mil/Product-Index/#/?view=search&keyword=${query}&isObsolete=false&modID=449&tabID=131`
+
+  return (
+    <div className={styles.epubs}>
+      <h3>Looking for a form?</h3>
+      <p>Launch your query on ePubs!</p>
+      <LinkTo
+        href={ePubsSearch}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="usa-button">
+        Search ePubs
+      </LinkTo>
+    </div>
+  )
+}
+
+export default EPubsCard

--- a/src/components/EPubsCard/EPubsCard.tsx
+++ b/src/components/EPubsCard/EPubsCard.tsx
@@ -7,7 +7,7 @@ type PropTypes = {
 }
 
 const EPubsCard = ({ query }: PropTypes) => {
-  const ePubsSearch = `https://www.e-publishing.af.mil/Product-Index/#/?view=search&keyword=${query}&isObsolete=false&modID=449&tabID=131`
+  const ePubsSearch = `https://search.usa.gov/search?affiliate=afpw_epubs&query=${query}`
 
   return (
     <div className={styles.epubs}>

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -4,6 +4,7 @@ import {
   Breadcrumb,
   BreadcrumbLink,
   GridContainer,
+  Grid,
 } from '@trussworks/react-uswds'
 
 import { client } from 'lib/keystoneClient'
@@ -12,6 +13,7 @@ import { useUser } from 'hooks/useUser'
 import { withArticleLayout } from 'layout/DefaultLayout/ArticleLayout'
 import NavLink, { NavLinkProps } from 'components/util/NavLink/NavLink'
 import PageHeader from 'components/PageHeader/PageHeader'
+import EPubsCard from 'components/EPubsCard/EPubsCard'
 import { SEARCH } from 'operations/cms/queries/search'
 import { SearchBanner } from 'components/SearchBanner/SearchBanner'
 import { SearchResultItem } from 'components/SearchResultItem/SearchResultItem'
@@ -62,17 +64,25 @@ const Search = ({
                 {resultString} for ‘{query}’
               </h2>
             </div>
+
             {results.length > 0 ? (
               <>
-                <ol className={styles.searchResults}>
-                  {results.map((i: SearchResultRecord) => {
-                    return (
-                      <li key={`result_${i.id}`}>
-                        <SearchResultItem item={i} />
-                      </li>
-                    )
-                  })}
-                </ol>
+                <Grid row gap>
+                  <Grid tablet={{ col: 2 }}>
+                    <EPubsCard query={query} />
+                  </Grid>
+
+                  <ol className={styles.searchResults}>
+                    {results.map((i: SearchResultRecord) => {
+                      return (
+                        <li key={`result_${i.id}`}>
+                          <SearchResultItem item={i} />
+                        </li>
+                      )
+                    })}
+                  </ol>
+                </Grid>
+
                 <SearchBanner
                   icon={
                     <img
@@ -90,21 +100,24 @@ const Search = ({
                 </SearchBanner>
               </>
             ) : (
-              <SearchBanner
-                icon={
-                  <img
-                    src="/assets/images/moon-flag.svg"
-                    alt="Icon of the US flag on the moon"
-                  />
-                }>
-                <div>
-                  <h3>There are no results that match that query.</h3>
-                  <p>
-                    It seems you didn’t find what you were looking for. Please
-                    search again with different keywords.
-                  </p>
-                </div>
-              </SearchBanner>
+              <>
+                <EPubsCard query={query} />
+                <SearchBanner
+                  icon={
+                    <img
+                      src="/assets/images/moon-flag.svg"
+                      alt="Icon of the US flag on the moon"
+                    />
+                  }>
+                  <div>
+                    <h3>There are no results that match that query.</h3>
+                    <p>
+                      It seems you didn’t find what you were looking for. Please
+                      search again with different keywords.
+                    </p>
+                  </div>
+                </SearchBanner>
+              </>
             )}
           </>
         )}

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -67,20 +67,22 @@ const Search = ({
 
             {results.length > 0 ? (
               <>
-                <Grid row gap>
-                  <Grid tablet={{ col: 2 }}>
+                <Grid row gap="md">
+                  <Grid col="auto">
                     <EPubsCard query={query} />
                   </Grid>
 
-                  <ol className={styles.searchResults}>
-                    {results.map((i: SearchResultRecord) => {
-                      return (
-                        <li key={`result_${i.id}`}>
-                          <SearchResultItem item={i} />
-                        </li>
-                      )
-                    })}
-                  </ol>
+                  <Grid col="fill">
+                    <ol className={styles.searchResults}>
+                      {results.map((i: SearchResultRecord) => {
+                        return (
+                          <li key={`result_${i.id}`}>
+                            <SearchResultItem item={i} />
+                          </li>
+                        )
+                      })}
+                    </ol>
+                  </Grid>
                 </Grid>
 
                 <SearchBanner
@@ -100,24 +102,28 @@ const Search = ({
                 </SearchBanner>
               </>
             ) : (
-              <>
-                <EPubsCard query={query} />
-                <SearchBanner
-                  icon={
-                    <img
-                      src="/assets/images/moon-flag.svg"
-                      alt="Icon of the US flag on the moon"
-                    />
-                  }>
-                  <div>
-                    <h3>There are no results that match that query.</h3>
-                    <p>
-                      It seems you didn’t find what you were looking for. Please
-                      search again with different keywords.
-                    </p>
-                  </div>
-                </SearchBanner>
-              </>
+              <Grid row gap="md">
+                <Grid col="auto">
+                  <EPubsCard query={query} />
+                </Grid>
+                <Grid col="fill">
+                  <SearchBanner
+                    icon={
+                      <img
+                        src="/assets/images/moon-flag.svg"
+                        alt="Icon of the US flag on the moon"
+                      />
+                    }>
+                    <div>
+                      <h3>There are no results that match that query.</h3>
+                      <p>
+                        It seems you didn’t find what you were looking for.
+                        Please search again with different keywords.
+                      </p>
+                    </div>
+                  </SearchBanner>
+                </Grid>
+              </Grid>
             )}
           </>
         )}

--- a/src/styles/pages/search.module.scss
+++ b/src/styles/pages/search.module.scss
@@ -23,3 +23,7 @@
     margin-bottom: units(6);
   }
 }
+
+.noResults {
+  display: flex;
+}


### PR DESCRIPTION
# SC-380

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Displays an option for the user to search against the e-Pubs site after they perform a search on the portal 
<!-- description and/or list of proposed changes -->

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Manually navigate to `http://localhost:3000/search`
- Search for a term (ex: 'pt', 'quill').
- After the search results appear/don't appear, click the 'Seach ePubs' button. A new tab should open and automatically search ePubs using the same query from the portal.
- Also try searching phrases that contain spaces, and see if the ePubs search is consistent.

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup
Make sure you are running the portal client & required services (ie., yarn portal:up in the CMS repo)
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps

### As the original developer, I have

- [x] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [x] Created new stories in Storybook if applicable
  - [x] Checked that all Storybook accessibility checks are passing
- [x] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
- [ ] Requested a design review for user-facing changes

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [x] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR


