### PR TITLE
chore: add Noah as temporary code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default owners for everything
 
-* @abbyoung @esacteksab @gidjin
+* @abbyoung @esacteksab @gidjin @noahfirth
 
 # Github settings
 


### PR DESCRIPTION
# SC-713

Adding @noahfirth and as a code owner while other engineers are out on vacation so we can merge work without being blocked.
