### PR TITLE
test: improve coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 90,
-      branches: 87,
+      branches: 88,
       functions: 90,
       lines: 90,
     },

--- a/src/components/FeedbackCard/FeedbackCard.test.tsx
+++ b/src/components/FeedbackCard/FeedbackCard.test.tsx
@@ -2,11 +2,14 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 import React from 'react'
 
 import FeedbackCard from './FeedbackCard'
+
+// importing these to spyOn the useAnalytics call
+import * as analyticsHooks from 'stores/analyticsContext'
 
 describe('Feedback Card component', () => {
   it('renders a feedback card', () => {
@@ -21,5 +24,45 @@ describe('Feedback Card component', () => {
     expect(
       screen.getByRole('link', { name: 'Send us feedback' })
     ).toBeInTheDocument()
+  })
+
+  describe('trackEvent functions called', () => {
+    const mockTrackEvents = jest.fn()
+
+    beforeEach(() => {
+      // need to clear the mock since the var mockTrackEvents carries over both calls
+      mockTrackEvents.mockClear()
+
+      // mock out the return of useAnalytics since we just need to check that it's called not what it does
+      jest.spyOn(analyticsHooks, 'useAnalytics').mockImplementation(() => {
+        return { push: jest.fn(), trackEvent: mockTrackEvents }
+      })
+
+      render(<FeedbackCard />)
+    })
+
+    it("calls trackEvent when clicking 'Send us feedback' link", () => {
+      const link = screen.getByRole('link', { name: 'Send us feedback' })
+
+      fireEvent.click(link)
+
+      expect(mockTrackEvents).toHaveBeenCalledTimes(1)
+      expect(mockTrackEvents).toHaveBeenCalledWith(
+        'Feedback',
+        'Send us feedback'
+      )
+    })
+
+    it("calls trackEvent when clicking 'feedback@ussforbit.us' link", () => {
+      const link = screen.getByRole('link', { name: 'feedback@ussforbit.us' })
+
+      fireEvent.click(link)
+
+      expect(mockTrackEvents).toHaveBeenCalledTimes(1)
+      expect(mockTrackEvents).toHaveBeenCalledWith(
+        'Feedback',
+        'feedback@ussforbit.us'
+      )
+    })
   })
 })

--- a/src/components/modals/EditCustomLinkModal.test.tsx
+++ b/src/components/modals/EditCustomLinkModal.test.tsx
@@ -12,64 +12,96 @@ import { renderWithModalRoot } from '../../testHelpers'
 import EditCustomLinkModal from './EditCustomLinkModal'
 
 describe('EditCustomLinkModal', () => {
-  const mockBookmark = {
-    _id: ObjectId(),
-    label: 'My Custom Link',
-    url: 'http://www.example.com',
-  }
   const mockOnSave = jest.fn()
   const mockOnCancel = jest.fn()
   const mockOnDelete = jest.fn()
 
-  beforeEach(() => {
-    const modalRef = createRef<ModalRef>()
-    renderWithModalRoot(
-      <EditCustomLinkModal
-        bookmark={mockBookmark}
-        modalRef={modalRef}
-        onSave={mockOnSave}
-        onCancel={mockOnCancel}
-        onDelete={mockOnDelete}
-      />
-    )
+  describe('with bookmark filled in', () => {
+    const mockBookmark = {
+      _id: ObjectId(),
+      label: 'My Custom Link',
+      url: 'http://www.example.com',
+    }
+
+    beforeEach(() => {
+      const modalRef = createRef<ModalRef>()
+      renderWithModalRoot(
+        <EditCustomLinkModal
+          bookmark={mockBookmark}
+          modalRef={modalRef}
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          onDelete={mockOnDelete}
+        />
+      )
+    })
+
+    it('renders a form to edit a custom link', () => {
+      expect(screen.getByRole('heading')).toHaveTextContent('Edit custom link')
+
+      const labelInput = screen.getByLabelText('Name')
+      expect(labelInput).toHaveValue(mockBookmark.label)
+      userEvent.clear(labelInput)
+      userEvent.type(labelInput, 'Edited link')
+
+      const urlInput = screen.getByLabelText('URL')
+      expect(urlInput).toHaveValue(mockBookmark.url)
+
+      userEvent.click(screen.getByRole('button', { name: 'Save custom link' }))
+      expect(mockOnSave).toHaveBeenCalledWith('Edited link', mockBookmark.url)
+    })
+
+    it('can delete the custom link', () => {
+      userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+      expect(mockOnDelete).toHaveBeenCalled()
+    })
+
+    it('can cancel out of the modal', () => {
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(mockOnCancel).toHaveBeenCalled()
+    })
+
+    it('cancelling resets the value of the text inputs', () => {
+      expect(screen.getByRole('heading')).toHaveTextContent('Edit custom link')
+
+      const labelInput = screen.getByLabelText('Name')
+      userEvent.type(labelInput, 'My Custom Link')
+      const urlInput = screen.getByLabelText('URL')
+      userEvent.type(urlInput, 'http://www.example.com')
+
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(mockOnCancel).toHaveBeenCalled()
+      expect(screen.getByLabelText('Name')).toHaveValue(mockBookmark.label)
+      expect(screen.getByLabelText('URL')).toHaveValue(mockBookmark.url)
+    })
   })
 
-  it('renders a form to edit a custom link', () => {
-    expect(screen.getByRole('heading')).toHaveTextContent('Edit custom link')
+  describe('without bookmark filled in', () => {
+    const mockBookmark = {
+      _id: ObjectId(),
+      url: '',
+    }
 
-    const labelInput = screen.getByLabelText('Name')
-    expect(labelInput).toHaveValue(mockBookmark.label)
-    userEvent.clear(labelInput)
-    userEvent.type(labelInput, 'Edited link')
+    beforeEach(() => {
+      const modalRef = createRef<ModalRef>()
+      renderWithModalRoot(
+        <EditCustomLinkModal
+          bookmark={mockBookmark}
+          modalRef={modalRef}
+          onSave={mockOnSave}
+          onCancel={mockOnCancel}
+          onDelete={mockOnDelete}
+        />
+      )
+    })
 
-    const urlInput = screen.getByLabelText('URL')
-    expect(urlInput).toHaveValue(mockBookmark.url)
+    it('cancelling resets the value of the text inputs', () => {
+      expect(screen.getByRole('heading')).toHaveTextContent('Edit custom link')
 
-    userEvent.click(screen.getByRole('button', { name: 'Save custom link' }))
-    expect(mockOnSave).toHaveBeenCalledWith('Edited link', mockBookmark.url)
-  })
-
-  it('can delete the custom link', () => {
-    userEvent.click(screen.getByRole('button', { name: 'Delete' }))
-    expect(mockOnDelete).toHaveBeenCalled()
-  })
-
-  it('can cancel out of the modal', () => {
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(mockOnCancel).toHaveBeenCalled()
-  })
-
-  it('cancelling resets the value of the text inputs', () => {
-    expect(screen.getByRole('heading')).toHaveTextContent('Edit custom link')
-
-    const labelInput = screen.getByLabelText('Name')
-    userEvent.type(labelInput, 'My Custom Link')
-    const urlInput = screen.getByLabelText('URL')
-    userEvent.type(urlInput, 'http://www.example.com')
-
-    userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
-    expect(mockOnCancel).toHaveBeenCalled()
-    expect(screen.getByLabelText('Name')).toHaveValue(mockBookmark.label)
-    expect(screen.getByLabelText('URL')).toHaveValue(mockBookmark.url)
+      userEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(mockOnCancel).toHaveBeenCalled()
+      expect(screen.getByLabelText('Name')).toHaveValue('')
+      expect(screen.getByLabelText('URL')).toHaveValue('')
+    })
   })
 })

--- a/src/lib/getAbsoluteUrl.test.ts
+++ b/src/lib/getAbsoluteUrl.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { IncomingMessage } from 'http'
+import { getAbsoluteUrl } from './getAbsoluteUrl'
+
+describe('getAbsoluteUrl', () => {
+  describe('with no parameters', () => {
+    it('returns localhost with no parameters', () => {
+      const expected = {
+        protocol: 'http:',
+        origin: 'http://localhost',
+        host: 'localhost',
+      }
+      expect(getAbsoluteUrl()).toStrictEqual(expected)
+    })
+  })
+
+  describe('with request only', () => {
+    it('returns correctly with x-forwarded-host header set', () => {
+      const expected = {
+        protocol: 'https:',
+        origin: 'https://example.com',
+        host: 'example.com',
+      }
+      const req = {
+        headers: { 'x-forwarded-host': 'example.com' },
+      } as unknown as IncomingMessage
+      expect(getAbsoluteUrl(req)).toStrictEqual(expected)
+    })
+
+    it('returns correctly with host header set', () => {
+      const expected = {
+        protocol: 'https:',
+        origin: 'https://example.org',
+        host: 'example.org',
+      }
+      const req = {
+        headers: { host: 'example.org' },
+      } as IncomingMessage
+      expect(getAbsoluteUrl(req)).toStrictEqual(expected)
+    })
+  })
+
+  describe('with setLocalhost passed', () => {
+    it('returns custom localhost', () => {
+      const expected = {
+        protocol: 'http:',
+        origin: 'http://custom.example.local',
+        host: 'custom.example.local',
+      }
+      expect(getAbsoluteUrl(undefined, 'custom.example.local')).toStrictEqual(
+        expected
+      )
+    })
+
+    it('returns correctly with host header set', () => {
+      const expected = {
+        protocol: 'https:',
+        origin: 'https://example.org',
+        host: 'example.org',
+      }
+      const req = {
+        headers: { host: 'example.org' },
+      } as IncomingMessage
+      expect(getAbsoluteUrl(req, 'custom.example.com')).toStrictEqual(expected)
+    })
+  })
+})


### PR DESCRIPTION
# SC-739

For some reason we started having coverage failures on code that had previously passed the coverage threshold. To alleviate that I've added some more tests to improve coverage.

## Reviewer notes

I'm still new to typescript so hopefully I've done things correctly. Please flag anything that gives you pause.

## Setup

Run the tests with coverage and see that it passes

```sh
yarn test --coverage
```

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [X] Created/modified automated unit tests in Jest

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed