### PR TITLE
ci: filter paths for github actions

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -2,6 +2,9 @@ name: Automated Docker Build Main Push C1 Artifactory
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,8 +13,14 @@ name: 'CodeQL'
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     # The branches below must be a subset of the branches above
     branches: [main]
   schedule:

--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -2,8 +2,14 @@ name: Cypress E2E tests
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
 
 jobs:

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -2,6 +2,9 @@ name: Automated Docker Build Main Push AWS Dev
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
 
 jobs:
@@ -57,7 +60,7 @@ jobs:
           echo $DEV_CERT > dev-saml.pem
           echo $TEST_CERT > test-saml.pem
           echo $PROD_CERT > prod-saml.pem
-          
+
       - name: Build and push
         uses: docker/build-push-action@1cb9d22b932e4832bb29793b7777ec860fc1cde0 # tag=v3
         with:
@@ -113,7 +116,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           ignore-unfixed: true
-          
+
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@2ca79b6fa8d3ec278944088b4aa5f46912db5d63 # tag=v2
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -2,8 +2,14 @@ name: Node CI
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
 
 jobs:

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -3,6 +3,9 @@ name: Lint PR
 on:
   pull_request_target:
     types: [opened, edited, synchronize]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches:
       - main
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -2,6 +2,9 @@ name: Deploy Storybook to Github Pages
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md**'
     branches: [main]
 
 jobs:


### PR DESCRIPTION
As discussed in eng sync and similar to https://github.com/USSF-ORBIT/ussf-portal-cms/pull/107 this filters paths so github actions don't always run unnecessarily. 