### PR TITLE
chore: disabling the dismissal of stale reviews

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -148,7 +148,7 @@ branches:
     protection:
       required_pull_request_reviews:
         required_approving_review_count: 1
-        dismiss_stale_reviews: true
+        dismiss_stale_reviews: false
         require_code_owner_reviews: true
         dismissal_restrictions:
           users: []


### PR DESCRIPTION
Like the PR in the cms repo, this value is unchecked in the UI but also configured here. This is just updating this file to reflect our desired state, to not dismiss stale reviews.