### PR TITLE
ci: optimize docker build cache performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,20 +8,29 @@ RUN apt-get update \
 
 WORKDIR /app
 
-COPY . .
+COPY ["package*.json", "yarn.lock", "./"]
+
+COPY ./scripts/ /app/scripts/
 
 RUN yarn install --frozen-lockfile
+
+COPY ["codegen.yml", "next.config.js", "tsconfig.json", "./"]"
+
+COPY ./src/ /app/src/
+
+RUN yarn prebuild
+
+RUN yarn build
+
+# Install only production deps this time
+RUN yarn install --production --ignore-scripts --prefer-offline
 
 ARG BUILD
 
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV IMAGE_TAG=${BUILD}
 
-RUN yarn prebuild
-RUN yarn build
-
-# Install only production deps this time
-RUN yarn install --production --ignore-scripts --prefer-offline
+COPY . .
 
 ##--------- Stage: e2e ---------##
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ COPY ./src/ /app/src/
 
 RUN yarn prebuild
 
+COPY ["*.ts", ".eslintignore", ".eslintrc.json", "babel.config.js", "./"]
+
+COPY ./public/ /app/public/
+
 RUN yarn build
 
 # Install only production deps this time

--- a/next.config.js
+++ b/next.config.js
@@ -25,9 +25,6 @@ module.exports = withBundleAnalyzer({
 
     return config
   },
-  generateBuildId: async () => {
-    return process.env.IMAGE_TAG
-  },
   reactStrictMode: true,
   // swcMinify: true,
   async headers() {


### PR DESCRIPTION
# SC-916

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- separate single docker `COPY` layer into multiple `COPY` layers so cache is not invalidated on every run
- move docker `BUILD ARG` to end of builder stage and remove `Build Id` from `next build`. Possible future PR to populate `Build Id` in sysinfo at run time

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

To test the docker build, run something like this:
```
docker build . --target=e2e --tag=portal-client:<your-tag-here>
```
I recommend cloning the [e2e repo](https://github.com/USSF-ORBIT/ussf-portal) and running `yarn services:up` from inside the /e2e folder. This will test the Dockerfile changes with `docker compose`.

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Checked that the E2E test build is not failing

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
