### PR TITLE
[WIP]feat: Add Light / Dark mode toggle to the portal

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -32,6 +32,17 @@ describe('Header component', () => {
     expect(screen.getAllByRole('link')).toHaveLength(2)
   })
 
+  it('can click an item from the About Us dropdown', () => {
+    render(<Header />)
+
+    const aboutTheUSSF = screen.getByTestId('nav-about-ussf')
+    expect(aboutTheUSSF).not.toBeVisible()
+
+    const dropdown = screen.getByTestId('nav-about-us-dropdown')
+    userEvent.click(dropdown)
+    expect(aboutTheUSSF).toBeVisible()
+  })
+
   it('can toggle navigation on smaller screen sizes', () => {
     render(<Header />)
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -41,7 +41,11 @@ const Header = () => {
   }
 
   const aboutUsDropdownItems = [
-    <NavLink href="/about-us" key="one" onClick={() => setIsOpen([false])}>
+    <NavLink
+      data-testid="nav-about-ussf"
+      href="/about-us"
+      key="one"
+      onClick={() => setIsOpen([false])}>
       About the USSF
     </NavLink>,
     <NavLink
@@ -55,6 +59,7 @@ const Header = () => {
   const navItems = [
     <>
       <NavDropDownButton
+        data-testid="nav-about-us-dropdown"
         menuId="aboutUsDropdown"
         onToggle={(): void => {
           onToggle(0)

--- a/src/components/ThemeToggle/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle/ThemeToggle.module.scss
@@ -1,0 +1,11 @@
+@import 'styles/uswdsDependencies';
+@import 'styles/sfds/sfdsDependencies';
+
+.toggleContainer {
+  position: absolute;
+  width: 132px;
+  height: 30px;
+  left: 0px;
+  top: 0px;
+  background: $theme-aurora-dark;
+}

--- a/src/components/ThemeToggle/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle/ThemeToggle.module.scss
@@ -1,11 +1,21 @@
 @import 'styles/uswdsDependencies';
 @import 'styles/sfds/sfdsDependencies';
 
-.toggleContainer {
+.toggleButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   position: absolute;
   width: 132px;
   height: 30px;
   left: 0px;
   top: 0px;
   background: $theme-aurora-dark;
+  border-radius: 4px;
+  border-style: none;
+  outline: none;
+
+  &:hover {
+    cursor: pointer;
+  }
 }

--- a/src/components/ThemeToggle/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle/ThemeToggle.module.scss
@@ -14,6 +14,7 @@
   border-radius: 4px;
   border-style: none;
   outline: none;
+  text-transform: uppercase;
 
   &:hover {
     cursor: pointer;

--- a/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ThemeToggle from './ThemeToggle'
+
+describe('ThemeToggle component', () => {
+  it('renders the component', () => {
+    render(<ThemeToggle />)
+
+    const toggleBtn = screen.getByTestId('theme-toggle')
+    expect(toggleBtn).toBeVisible()
+
+    userEvent.click(toggleBtn)
+    expect(screen.getAllByText('light mode')).toHaveLength(1)
+  })
+})

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -10,7 +10,11 @@ const ThemeToggle = () => {
   }
 
   return (
-    <button type="button" onClick={handleTheme} className={styles.toggleButton}>
+    <button
+      type="button"
+      onClick={handleTheme}
+      className={styles.toggleButton}
+      data-testid="theme-toggle">
       {theme === 'light' ? 'dark' : 'light'} mode
     </button>
   )

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,11 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styles from './ThemeToggle.module.scss'
 
 const ThemeToggle = () => {
+  // TODO: Replace this with the actual logic for changing the theme
+  const [theme, setTheme] = useState('light')
+
+  const handleTheme = () => {
+    return theme === 'light' ? setTheme('dark') : setTheme('light')
+  }
+
   return (
-    <div className={styles.toggleContainer}>
-      <p>LIGHT MODE</p>
-    </div>
+    <button type="button" onClick={handleTheme} className={styles.toggleButton}>
+      {theme}
+    </button>
   )
 }
 

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import styles from './ThemeToggle.module.scss'
+
+const ThemeToggle = () => {
+  return (
+    <div className={styles.toggleContainer}>
+      <p>LIGHT MODE</p>
+    </div>
+  )
+}
+
+export default ThemeToggle

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -11,7 +11,7 @@ const ThemeToggle = () => {
 
   return (
     <button type="button" onClick={handleTheme} className={styles.toggleButton}>
-      {theme}
+      {theme === 'light' ? 'dark' : 'light'} mode
     </button>
   )
 }


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
