### PR TITLE
feat: update user model for saving dark mode

### DIFF
--- a/src/models/Bookmark.test.ts
+++ b/src/models/Bookmark.test.ts
@@ -33,7 +33,10 @@ describe('Bookmark Model', () => {
     // Create test user
     const testUserId = 'testUserId'
     const displayName = 'Floyd King'
-    await User.createOne(testUserId, [exampleCollection], displayName, { db })
+    const theme = 'light'
+    await User.createOne(testUserId, [exampleCollection], displayName, theme, {
+      db,
+    })
     const testUser = await User.findOne(testUserId, { db })
 
     // Test user comes with an example collection

--- a/src/models/Collection.test.ts
+++ b/src/models/Collection.test.ts
@@ -145,7 +145,10 @@ describe('Collection Model', () => {
     // Create test user
     testUserId = 'testUserId'
     const displayName = 'Floyd King'
-    await User.createOne(testUserId, [exampleCollection], displayName, { db })
+    const theme = 'light'
+    await User.createOne(testUserId, [exampleCollection], displayName, theme, {
+      db,
+    })
     const testUser = await User.findOne(testUserId, { db })
     exampleCollectionId = testUser.mySpace[0]._id
   })

--- a/src/models/MySpace.test.ts
+++ b/src/models/MySpace.test.ts
@@ -25,7 +25,10 @@ describe('My Space model', () => {
 
     // Create a test user (with one default collection)
     const displayName = 'Floyd King'
-    await User.createOne(testUserId, [exampleCollection], displayName, { db })
+    const theme = 'light'
+    await User.createOne(testUserId, [exampleCollection], displayName, theme, {
+      db,
+    })
   })
 
   afterAll(async () => {

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -67,6 +67,14 @@ describe('User model', () => {
       expect(updatedUser.displayName).toEqual(displayName)
     })
 
+    it('throws an error if user is not found during SET', async () => {
+      await expect(
+        User.setDisplayName({ userId: 'thisuserdoesnotexist', displayName: 'any name' }, {
+          db,
+        })
+      ).rejects.toThrow('UserModel Error: error in setDisplayName no user found')
+    })
+
     it('can get the displayName of a user', async () => {
       const foundDisplayName = await User.getDisplayName('testUserId', {
         db,
@@ -74,12 +82,12 @@ describe('User model', () => {
       expect(foundDisplayName).toEqual('Updated Name')
     })
 
-    it('throws an error if displayName is not found', async () => {
+    it('throws an error if user is not found during GET', async () => {
       await expect(
         User.getDisplayName('thisuserdoesnotexist', {
           db,
         })
-      ).rejects.toThrow('UserModel Error: error in getDisplayName')
+      ).rejects.toThrow('UserModel Error: error in getDisplayName no user found')
     })
   })
 })

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -31,13 +31,23 @@ describe('User model', () => {
       userId: 'testUserId',
       mySpace: [exampleCollection1],
       displayName: 'Floyd King',
+      theme: 'light',
     }
 
     const displayName = 'Floyd King'
-    await User.createOne('testUserId', [exampleCollection], displayName, { db })
+    await User.createOne(
+      'testUserId',
+      [exampleCollection],
+      displayName,
+      'light',
+      { db }
+    )
 
     const insertedUser = await User.findOne('testUserId', { db })
 
+    expect(insertedUser.userId).toBe(expectedUser.userId)
+    expect(insertedUser.displayName).toBe(expectedUser.displayName)
+    expect(insertedUser.theme).toBe(expectedUser.theme)
     expect(insertedUser.mySpace[0].title).toContain(
       expectedUser.mySpace[0].title
     )

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -43,41 +43,43 @@ describe('User model', () => {
     )
   })
 
-  it('can edit the displayName of a user', async () => {
-    const expectedUser = {
-      _id: expect.anything(),
-      userId: 'testUserId',
-      mySpace: [exampleCollection1],
-      displayName: 'Updated Name',
-    }
-
-    const { userId, displayName } = expectedUser
-    await User.editOne({ userId, displayName }, { db })
-
-    const updatedUser = await User.findOne(userId, { db })
-
-    expect(updatedUser.displayName).toEqual(displayName)
-  })
-
-  it('can get the displayName of a user', async () => {
-    const foundDisplayName = await User.getDisplayName('testUserId', {
-      db,
-    })
-    expect(foundDisplayName).toEqual('Updated Name')
-  })
-
-  it('throws an error if displayName is not found', async () => {
-    await expect(
-      User.getDisplayName('thisuserdoesnotexist', {
-        db,
-      })
-    ).rejects.toThrow()
-  })
-
   it('returns null if finding a user that doesn’t exist', async () => {
     const testUserId = 'noSuchUser'
 
     const foundUser = await User.findOne(testUserId, { db })
     expect(foundUser).toEqual(null)
+  })
+
+  describe('displayName', () => {
+    it('can edit the displayName of a user', async () => {
+      const expectedUser = {
+        _id: expect.anything(),
+        userId: 'testUserId',
+        mySpace: [exampleCollection1],
+        displayName: 'Updated Name',
+      }
+
+      const { userId, displayName } = expectedUser
+      await User.setDisplayName({ userId, displayName }, { db })
+
+      const updatedUser = await User.findOne(userId, { db })
+
+      expect(updatedUser.displayName).toEqual(displayName)
+    })
+
+    it('can get the displayName of a user', async () => {
+      const foundDisplayName = await User.getDisplayName('testUserId', {
+        db,
+      })
+      expect(foundDisplayName).toEqual('Updated Name')
+    })
+
+    it('throws an error if displayName is not found', async () => {
+      await expect(
+        User.getDisplayName('thisuserdoesnotexist', {
+          db,
+        })
+      ).rejects.toThrow('UserModel Error: error in getDisplayName')
+    })
   })
 })

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -69,10 +69,15 @@ describe('User model', () => {
 
     it('throws an error if user is not found during SET', async () => {
       await expect(
-        User.setDisplayName({ userId: 'thisuserdoesnotexist', displayName: 'any name' }, {
-          db,
-        })
-      ).rejects.toThrow('UserModel Error: error in setDisplayName no user found')
+        User.setDisplayName(
+          { userId: 'thisuserdoesnotexist', displayName: 'any name' },
+          {
+            db,
+          }
+        )
+      ).rejects.toThrow(
+        'UserModel Error: error in setDisplayName no user found'
+      )
     })
 
     it('can get the displayName of a user', async () => {
@@ -87,7 +92,53 @@ describe('User model', () => {
         User.getDisplayName('thisuserdoesnotexist', {
           db,
         })
-      ).rejects.toThrow('UserModel Error: error in getDisplayName no user found')
+      ).rejects.toThrow(
+        'UserModel Error: error in getDisplayName no user found'
+      )
+    })
+  })
+
+  describe('theme', () => {
+    it('can edit the theme of a user', async () => {
+      const expectedUser = {
+        _id: expect.anything(),
+        userId: 'testUserId',
+        mySpace: [exampleCollection1],
+        theme: 'dark',
+      }
+
+      const { userId, theme } = expectedUser
+      await User.setTheme({ userId, theme }, { db })
+
+      const updatedUser = await User.findOne(userId, { db })
+
+      expect(updatedUser.theme).toEqual(theme)
+    })
+
+    it('throws an error if theme is not found on SET', async () => {
+      await expect(
+        User.setTheme(
+          { userId: 'thisuserdoesnotexist', theme: 'dark' },
+          {
+            db,
+          }
+        )
+      ).rejects.toThrow('UserModel Error: error in setTheme no user found')
+    })
+
+    it('can get the theme of a user', async () => {
+      const foundTheme = await User.getTheme('testUserId', {
+        db,
+      })
+      expect(foundTheme).toEqual('dark')
+    })
+
+    it('throws an error if theme is not found on GET', async () => {
+      await expect(
+        User.getTheme('thisuserdoesnotexist', {
+          db,
+        })
+      ).rejects.toThrow('UserModel Error: error in getTheme no user found')
     })
   })
 })

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -23,12 +23,14 @@ const UserModel = {
     userId: string,
     initCollections: CollectionRecords,
     displayName: string,
+    theme: 'light' | 'dark',
     { db }: Context
   ) {
     const newUser: PortalUser = {
       userId,
       mySpace: [],
       displayName,
+      theme,
     }
 
     // Create user

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -9,6 +9,11 @@ type EditDisplayName = {
   displayName: string
 }
 
+type EditTheme = {
+  userId: string
+  theme: string
+}
+
 const UserModel = {
   async findOne(userId: string, { db }: Context) {
     const foundUser = await db.collection('users').findOne({ userId })
@@ -72,6 +77,36 @@ const UserModel = {
       throw new Error('UserModel Error: error in getDisplayName no user found')
     }
     return user.displayName
+  },
+  async setTheme({ userId, theme }: EditTheme, { db }: Context) {
+    const user = await UserModel.findOne(userId, { db })
+    if (!user) {
+      throw new Error('UserModel Error: error in setTheme no user found')
+    }
+
+    const query = {
+      userId: userId,
+    }
+
+    const updateDocument = {
+      $set: {
+        ...user,
+        theme: theme,
+      },
+    }
+
+    const result = await db
+      .collection('users')
+      .findOneAndUpdate(query, updateDocument, { returnDocument: 'after' })
+
+    return result.value
+  },
+  async getTheme(userId: string, { db }: Context) {
+    const user = await db.collection('users').findOne({ userId })
+    if (!user) {
+      throw new Error('UserModel Error: error in getTheme no user found')
+    }
+    return user.theme
   },
 }
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -45,6 +45,9 @@ const UserModel = {
     { db }: Context
   ) {
     const user = await UserModel.findOne(userId, { db })
+    if (!user) {
+      throw new Error('UserModel Error: error in setDisplayName no user found')
+    }
 
     const query = {
       userId: userId,
@@ -66,7 +69,7 @@ const UserModel = {
   async getDisplayName(userId: string, { db }: Context) {
     const user = await db.collection('users').findOne({ userId })
     if (!user) {
-      throw new Error('UserModel Error: error in getDisplayName')
+      throw new Error('UserModel Error: error in getDisplayName no user found')
     }
     return user.displayName
   },

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -4,7 +4,7 @@ import { CollectionModel } from './Collection'
 
 import type { PortalUser, CollectionRecords } from 'types/index'
 
-type EditOneInput = {
+type EditDisplayName = {
   userId: string
   displayName: string
 }
@@ -40,7 +40,10 @@ const UserModel = {
 
     return true
   },
-  async editOne({ userId, displayName }: EditOneInput, { db }: Context) {
+  async setDisplayName(
+    { userId, displayName }: EditDisplayName,
+    { db }: Context
+  ) {
     const user = await UserModel.findOne(userId, { db })
 
     const query = {
@@ -54,7 +57,11 @@ const UserModel = {
       },
     }
 
-    await db.collection('users').updateOne(query, updateDocument)
+    const result = await db
+      .collection('users')
+      .findOneAndUpdate(query, updateDocument, { returnDocument: 'after' })
+
+    return result.value
   },
   async getDisplayName(userId: string, { db }: Context) {
     const user = await db.collection('users').findOne({ userId })

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -105,7 +105,9 @@ export const apolloServer = new ApolloServer({
       if (!foundUser) {
         try {
           const initCollection = await getExampleCollection()
-          await User.createOne(userId, [initCollection], displayName, { db })
+          await User.createOne(userId, [initCollection], displayName, 'light', {
+            db,
+          })
         } catch (e) {
           // TODO log error
           // console.error('error in creating new user', e)

--- a/src/resolvers/index.test.ts
+++ b/src/resolvers/index.test.ts
@@ -18,6 +18,7 @@ import { RemoveBookmarkDocument } from 'operations/portal/mutations/removeBookma
 import { EditBookmarkDocument } from 'operations/portal/mutations/editBookmark.g'
 import { AddWidgetDocument } from 'operations/portal/mutations/addWidget.g'
 import { RemoveWidgetDocument } from 'operations/portal/mutations/removeWidget.g'
+import { EditDisplayNameDocument } from 'operations/portal/mutations/editDisplayName.g'
 
 let server: ApolloServer
 let connection: typeof MongoClient
@@ -99,6 +100,11 @@ describe('GraphQL resolvers', () => {
       ],
       ['addWidget', AddWidgetDocument, { title: 'Recent news', type: 'News' }],
       ['removeWidget', RemoveWidgetDocument, { _id: `${testWidgetId}` }],
+      [
+        'editDisplayName',
+        EditDisplayNameDocument,
+        { userId: `${testWidgetId}`, displayName: 'New Name' },
+      ],
     ])(
       'the %s operation returns an authentication error',
       async (name, op, variables: VariableValues = {}) => {
@@ -663,6 +669,28 @@ describe('GraphQL resolvers', () => {
 
         expect(updated.data?.mySpace[0].bookmarks[0].cmsId).toBe(bookmark.cmsId)
         expect(updated.data?.mySpace[0].bookmarks[0].isRemoved).toBe(true)
+      })
+    })
+
+    describe('editDisplayName', () => {
+      it('edits an existing display name', async () => {
+        const editDisplayName = newPortalUser
+
+        const result = await server.executeOperation({
+          query: EditDisplayNameDocument,
+          variables: {
+            userId: `${editDisplayName.userId}`,
+            displayName: 'New Name',
+          },
+        })
+
+        const expectedData = {
+          userId: `${newPortalUser.userId}`,
+          displayName: 'New Name',
+        }
+
+        expect(result.errors).toBeUndefined()
+        expect(result.data).toMatchObject({ editDisplayName: expectedData })
       })
     })
   })

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -298,7 +298,7 @@ const resolvers = {
         )
       }
 
-      return UserModel.editOne({ userId, displayName }, { db })
+      return UserModel.setDisplayName({ userId, displayName }, { db })
     },
   },
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -160,6 +160,7 @@ export type PortalUser = {
   userId: string
   mySpace: Collection[]
   displayName: string
+  theme: string
 }
 
 export type SessionUser = SAMLUser & {


### PR DESCRIPTION
# SC-1030

## Proposed changes

Add `theme` as an attribute of the `User` model. 

## Reviewer notes

I refactored the `User.editOne` to be `User.setDisplayName` as well as added tests for its matching resolver. I did modify it to return data so that the test in the resolver could be written the same way as the others. Please let me know if this breaks something or violates a convention.

I declared `theme` to be of type `'light' | 'dark'` so that auto complete and typescript would know that it should only ever be `light` or `dark`, at least until we add `system` or other themes.

## Setup

I'm not sure there is a way to try this out yet since there is no graphql setup yet. But sc-1035 is next on my list so that should make it testable.

For now ensure tests pass
```sh
yarn test
```

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - SC-1035 will add a mutation to GraphQL to set theme, and ensure it's returned as part of the find user calls
  - SC-1031 will ensure that the saved setting is used when logging in
- [x] Created/modified automated unit tests in Jest
- For any new migrations/schema changes:
  - [x] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed