### PR TITLE
feat: add mutation for get and set theme

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@
 1. [Database migrations](#database-migrations)
 1. [PR linting](#pr-linting)
 1. [Testing](#testing)
+1. [Apollo Server Explorer](#apollo-server-explorer)
 1. [Releasing](#releasing)
 
 ## Environment Setup
@@ -338,6 +339,33 @@ The footer should also include `BREAKING CHANGE:` if the commit includes any bre
   - You can also run Cypress against the dev stack. Just note that the dev server does _not_ match the same behavior as when it is running in production, so Cypress tests should always also be verified against what is going to be deployed to production.
     - `docker compose up -d` (start the NextJS dev server at localhost:3000)
     - `yarn cypress:dev` (start the Cypress UI runner against the application)
+
+## Apollo Server Explorer
+
+Apollo server comes with a built in tool for executing graphql queries against your local server. It's disabled by default, but you can easily enable it. To do so switch the `ApolloServerPluginLandingPageDisabled` in `src/pages/api/graphql.tsx` to the below with `ApolloServerPluginLandingPageLocalDefault` instead. Note you will need to enable embedding to allow it to connect properly to your server. Details about the options are [documented here](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages)
+
+```diff
+diff --git a/src/pages/api/graphql.tsx b/src/pages/api/graphql.tsx
+index 5fd1b8d..1979e22 100644
+--- a/src/pages/api/graphql.tsx
++++ b/src/pages/api/graphql.tsx
+@@ -6,7 +6,11 @@ import {
+   ApolloError,
+   gql,
+ } from 'apollo-server-micro'
+-import { ApolloServerPluginLandingPageDisabled } from 'apollo-server-core'
++import { ApolloServerPluginLandingPageLocalDefault } from 'apollo-server-core'
+ import type { PageConfig } from 'next'
+
+ import { typeDefs } from '../../schema'
+@@ -64,7 +68,12 @@ const clientConnection = async () => {
+ export const apolloServer = new ApolloServer({
+   typeDefs,
+   resolvers,
+-  plugins: [ApolloServerPluginLandingPageDisabled()],
++  plugins: [ApolloServerPluginLandingPageLocalDefault({ embed: true })],
+   context: async ({ req, res }) => {
+```
 
 ## Releasing
 

--- a/src/__fixtures__/newPortalUser.ts
+++ b/src/__fixtures__/newPortalUser.ts
@@ -104,4 +104,5 @@ export const newPortalUser = {
   userId: 'CAMPBELL.BERNADETTE.5244446289',
   mySpace: [exampleCollection1, exampleCollection2],
   displayName: 'BERNADETTE CAMPBELL',
+  theme: 'dark',
 }

--- a/src/operations/portal/mutations/editTheme.graphql
+++ b/src/operations/portal/mutations/editTheme.graphql
@@ -1,0 +1,6 @@
+mutation editTheme($userId: String!, $theme: String!) {
+  editTheme(userId: $userId, theme: $theme) {
+    userId
+    theme
+  }
+}

--- a/src/operations/portal/queries/getTheme.graphql
+++ b/src/operations/portal/queries/getTheme.graphql
@@ -1,0 +1,3 @@
+query getTheme {
+  theme
+}

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -92,16 +92,6 @@ export const apolloServer = new ApolloServer({
         userId: userId,
       }
 
-      const updateDocument = {
-        $set: {
-          displayName: displayName,
-        },
-      }
-
-      if (foundUser && !foundUser.displayName) {
-        await db.collection('users').updateOne(query, updateDocument)
-      }
-
       if (!foundUser) {
         try {
           const initCollection = await getExampleCollection()
@@ -112,6 +102,26 @@ export const apolloServer = new ApolloServer({
           // TODO log error
           // console.error('error in creating new user', e)
           throw new ApolloError('Error creating new user')
+        }
+      } else {
+        // TODO we should be able to remove these once all exisitng users have the defaults set.
+        // set defaults for new fields if user found
+        if (!foundUser.displayName) {
+          const updateDocument = {
+            $set: {
+              displayName: displayName,
+            },
+          }
+          await db.collection('users').updateOne(query, updateDocument)
+        }
+
+        if (!foundUser.theme) {
+          const updateDocument = {
+            $set: {
+              theme: 'light',
+            },
+          }
+          await db.collection('users').updateOne(query, updateDocument)
         }
       }
 

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -64,6 +64,7 @@ const clientConnection = async () => {
 export const apolloServer = new ApolloServer({
   typeDefs,
   resolvers,
+  cache: 'bounded',
   plugins: [ApolloServerPluginLandingPageDisabled()],
   context: async ({ req, res }) => {
     const session = await getSession(req, res)

--- a/src/resolvers/index.test.ts
+++ b/src/resolvers/index.test.ts
@@ -19,6 +19,7 @@ import { EditBookmarkDocument } from 'operations/portal/mutations/editBookmark.g
 import { AddWidgetDocument } from 'operations/portal/mutations/addWidget.g'
 import { RemoveWidgetDocument } from 'operations/portal/mutations/removeWidget.g'
 import { EditDisplayNameDocument } from 'operations/portal/mutations/editDisplayName.g'
+import { GetDisplayNameDocument } from 'operations/portal/queries/getDisplayName.g'
 
 let server: ApolloServer
 let connection: typeof MongoClient
@@ -669,6 +670,20 @@ describe('GraphQL resolvers', () => {
 
         expect(updated.data?.mySpace[0].bookmarks[0].cmsId).toBe(bookmark.cmsId)
         expect(updated.data?.mySpace[0].bookmarks[0].isRemoved).toBe(true)
+      })
+    })
+
+    describe('getDisplayName', () => {
+      it('returns displayName of the user', async () => {
+        const result = await server.executeOperation({
+          query: GetDisplayNameDocument,
+        })
+
+        const expectedData = { ...newPortalUser }
+
+        expect(result.errors).toBeUndefined()
+
+        expect(result.data?.displayName).toEqual(expectedData.displayName)
       })
     })
 

--- a/src/resolvers/index.test.ts
+++ b/src/resolvers/index.test.ts
@@ -22,7 +22,6 @@ import { EditDisplayNameDocument } from 'operations/portal/mutations/editDisplay
 import { GetDisplayNameDocument } from 'operations/portal/queries/getDisplayName.g'
 import { EditThemeDocument } from 'operations/portal/mutations/editTheme.g'
 import { GetThemeDocument } from 'operations/portal/queries/getTheme.g'
-import { PortalUser } from 'types'
 
 let server: ApolloServer
 let connection: typeof MongoClient

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -84,6 +84,11 @@ type EditDisplayNameInput = {
   userId: string
   displayName: string
 }
+
+type EditThemeInput = {
+  userId: string
+  theme: 'light' | 'dark'
+}
 const resolvers = {
   OID: ObjectIdScalar,
   // Interface resolvers
@@ -125,7 +130,7 @@ const resolvers = {
     },
     displayName: async (
       _: undefined,
-      args: undefined,
+      _args: undefined,
       { db, user }: PortalUserContext
     ) => {
       if (!user) {
@@ -135,6 +140,19 @@ const resolvers = {
       }
 
       return UserModel.getDisplayName(user.userId, { db })
+    },
+    theme: async (
+      _: undefined,
+      _args: undefined,
+      { db, user }: PortalUserContext
+    ) => {
+      if (!user) {
+        throw new AuthenticationError(
+          'You must be logged in to perform this operation'
+        )
+      }
+
+      return UserModel.getTheme(user.userId, { db })
     },
   },
   Mutation: {
@@ -299,6 +317,19 @@ const resolvers = {
       }
 
       return UserModel.setDisplayName({ userId, displayName }, { db })
+    },
+    editTheme: async (
+      _: undefined,
+      { userId, theme }: EditThemeInput,
+      { db, user }: PortalUserContext
+    ) => {
+      if (!user) {
+        throw new AuthenticationError(
+          'You must be logged in to perform this operation'
+        )
+      }
+
+      return UserModel.setTheme({ userId, theme }, { db })
     },
   },
 }

--- a/src/schema.tsx
+++ b/src/schema.tsx
@@ -40,6 +40,7 @@ export const typeDefs = gql`
     collections: [Collection!]!
     mySpace: [Widget!]!
     displayName: String!
+    theme: String!
   }
 
   type User {
@@ -47,6 +48,7 @@ export const typeDefs = gql`
     userId: String
     mySpace: [Collection]
     displayName: String
+    theme: String
   }
 
   type Mutation {
@@ -74,6 +76,7 @@ export const typeDefs = gql`
       label: String
     ): Bookmark
     editDisplayName(userId: String!, displayName: String!): User
+    editTheme(userId: String!, theme: String!): User
   }
 
   input BookmarkInput {


### PR DESCRIPTION
# SC-1035

## Proposed changes

This work is dependent on PR #772 and story sc-1030 and should be merged AFTER them. It adds the query to return the theme for the current user and the mutation to update the theme. Also modifies the apollo context to set a default theme if one is not present.

Since I was in the file that configures the Apollo server I also [applied their recommendation to bound the cache](https://www.apollographql.com/docs/apollo-server/performance/cache-backends/). As far as I can tell it is already using an internal cache but it is unbounded. Eventually we may want to configure it to use redis. This is for sc-707

## Reviewer notes

This is my first time modifying graphql stuff, please let me know if I missed something or didn't follow a convention I am not aware of.

## Setup

See the steps in `docs/development.md` to enable the Apollo Server Explorer. Then execute a query to get theme or set theme.

```graphql
query Query {
  displayName
  theme
}
```

```graphql
mutation EditTheme {
  editTheme(userId: "FLOYD.KING.376144527@testusers.cce.af.mil", theme: "dark") {
    theme
  }
}
```
---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - SC-1030 will update the model to support a theme PR #772 
  - SC-1031 will ensure that the saved setting is used when logging in
- [X] Created/modified automated unit tests in Jest
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Checked that the E2E test build is not failing

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed