### PR TITLE
dev: Dark mode support for My Space and related components

### DIFF
--- a/src/components/AddWidget/AddWidget.module.scss
+++ b/src/components/AddWidget/AddWidget.module.scss
@@ -4,8 +4,8 @@
 .addWidget {
   display: block;
   text-align: center;
-  background-color: rgba(220, 222, 224, 0.15);
-  border: 1px solid color('base-lighter');
+  background-color: var(--btn-add-widget-bg);
+  border: 1px solid var(--btn-add-widget-border);
   box-sizing: border-box;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.15);
   border-radius: 4px;
@@ -21,7 +21,7 @@
   cursor: pointer;
   border: none;
   background: transparent;
-  color: #585a5c;
+  color: var(--btn-add-widget);
   @include u-font-size('body', 'lg');
   font-family: $sfds-heading-font;
 
@@ -30,7 +30,7 @@
   }
 
   .plus {
-    color: rgba(0, 0, 0, 0.1);
+    color: var(--btn-add-widget-icon);
     svg {
       width: 70px;
       height: 70px;
@@ -39,7 +39,7 @@
 
   &:hover {
     .plus {
-      color: rgba(0, 0, 0, 0.25);
+      color: var(--btn-add-widget-icon-hover);
     }
   }
 }

--- a/src/components/NewsListItem/NewsListItem.module.scss
+++ b/src/components/NewsListItem/NewsListItem.module.scss
@@ -11,7 +11,7 @@
 a.articleLink {
   display: block;
   text-decoration: none;
-  color: $theme-black;
+  color: var(--article-link-text);
 
   &:hover {
     text-decoration: underline;
@@ -75,6 +75,7 @@ a.articleLink {
   margin-bottom: 0;
   margin-top: 0;
   flex-grow: 1;
+  color: var(--article-excerpt-text);
 
   .articleExcerptTruncate {
     display: -webkit-box;
@@ -85,6 +86,7 @@ a.articleLink {
     hyphens: auto;
     text-overflow: ellipsis;
     text-align: left;
+    color: var(--article-excerpt-text);
   }
 }
 

--- a/src/components/SelectableCollection/SelectableCollection.module.scss
+++ b/src/components/SelectableCollection/SelectableCollection.module.scss
@@ -53,5 +53,5 @@
   justify-content: center;
   opacity: 0;
   transition: opacity 0.12s;
-  background-color: rgba($grey, 0.8);
+  background-color: var(--widget-selected);
 }

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -58,6 +58,7 @@
   // Widgets
   --widget-bg: #{$theme-white};
   --widget-border: #{color(base-light)};
+  --widget-selected: #{rgba($grey, 0.8)};
 
   // Forms
   --form-combobox-bg: #{$theme-white};
@@ -139,6 +140,7 @@
   // Widgets
   --widget-bg: #{$theme-spacebase-darker};
   --widget-border: #{$theme-spacebase-darker};
+  --widget-selected: #{rgba($grey, 0.4)};
 
   // News
   --btn-box-bg: #{$theme-spacebase-light};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -121,7 +121,7 @@
   --btn-unstyled: #{$theme-aurora-dark};
   --btn-unstyled-hover: #{$theme-aurora-base};
 
-  --btn-primary-text: #{$theme-white};
+  --btn-primary-text: #{$theme-black};
 
   --btn-add-widget-border: #{$theme-spacebase-dark};
   --btn-add-widget-bg: #{$theme-spacebase-darker};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -15,6 +15,7 @@
   --paragraph-text: #{$theme-black};
 
   // Layout
+  --body-bg: #{$white};
   --bg: #{$theme-white};
   --text: #{$theme-black};
 
@@ -105,6 +106,7 @@
   --paragraph-text: #{$theme-white};
 
   // Layout
+  --body-bg: #{$theme-spacebase-dark};
   --bg: #{$theme-spacebase-dark};
   --text: #{$white};
 

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -37,6 +37,11 @@
 
   --disabled-btn-text: #{$theme-white};
 
+  --btn-add-widget-bg: rgba(220, 222, 224, 0.15);
+  --btn-add-widget-border: #{color('base-lighter')};
+  --btn-add-widget: #585a5c;
+  --btn-add-widget-icon: rgba(0, 0, 0, 0.1);
+  --btn-add-widget-icon-hover: rgba(0, 0, 0, 0.25);
   // Bookmark
   --bookmark-bg: transparent;
   --bookmark-border: #{color(base-light)};
@@ -80,6 +85,9 @@
   --category-externalnews-text: #{$white};
   --category-internalnews-bg: #{$category-internalnews-lighttheme};
   --category-internalnews-text: #{$white};
+
+  // Articles
+  --article-link-text: #{$theme-black};
 }
 
 /* ------------------------------------ */
@@ -109,6 +117,12 @@
   --btn-unstyled-hover: #{$theme-aurora-base};
 
   --btn-primary-text: #{$theme-white};
+
+  --btn-add-widget-border: #{$theme-spacebase-dark};
+  --btn-add-widget-bg: #{$theme-spacebase-darker};
+  --btn-add-widget: #{$theme-aurora-base};
+  --btn-add-widget-icon: #{$theme-white};
+  --btn-add-widget-icon-hover: #{$theme-spacebase-light};
 
   // Bookmark
   --bookmark-bg: #{$theme-ultraviolet-darkest};
@@ -156,6 +170,10 @@
   --form-input-text: #{$theme-white};
   --form-input-border: #{color(base-light)};
   --form-input-placeholder: #{$theme-white};
+
+  // Articles
+  --article-link-text: #{$theme-aurora-base};
+  --article-excerpt-text: #{$theme-white};
 
   // Filters for SVG color changes
   // Generated using https://codepen.io/sosuke/pen/Pjoqqp

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -12,6 +12,7 @@
   --link-primary-hover: #{$theme-ultraviolet-darker};
   --link-secondary: #{$theme-aurora-base};
   --link-secondary-hover: #{$theme-aurora-lighter};
+  --paragraph-text: #{$theme-black};
 
   // Layout
   --bg: #{$theme-white};
@@ -100,6 +101,7 @@
   --link-primary-hover: #{$theme-aurora-base};
   --link-secondary: #{$theme-ultraviolet-darkest};
   --link-secondary-hover: #{$theme-ultraviolet-darker};
+  --paragraph-text: #{$theme-white};
 
   // Layout
   --bg: #{$theme-spacebase-dark};

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -13,4 +13,5 @@
 body,
 #__next {
   min-height: 100vh;
+  background-color: var(--bg);
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -13,5 +13,5 @@
 body,
 #__next {
   min-height: 100vh;
-  background-color: var(--bg);
+  background-color: var(--body-bg);
 }

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -92,7 +92,7 @@
 
   p,
   .usa-prose ul {
-    color: $theme-black;
+    color: var(--paragraph-text);
   }
 
   .usa-prose,


### PR DESCRIPTION
# SC-1022

## Proposed changes

Adds Dark Mode theme support for:
- News widget on My Space
- Add Section button / section on My Space
- Feedback card in left sidebar on home page
- Selectable collection (when clicking Add section + choose existing > sites and apps > select collection)


## Reviewer notes

You can test by running the portal locally, and also by viewing the following components in Storybook > toggling the theme.

* Sections > everything in this subfolder should display properly
* Feedback Card


## Setup
To toggle between light and dark mode, open the dev tools in your browser when running the portal, then click Application > Local Storage > Set a key/value pair for theme, dark.

To toggle between light and dark mode in Storybook, click a component/Story, and click the theme toggle in the top toolbar.

<img width="826" alt="storybook-theme-toggle" src="https://user-images.githubusercontent.com/6007259/190700040-7ac0d388-a364-4b8f-a221-b19b46514568.png">


## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
