### PR TITLE
dev: extend connection timeout and add keystone db health check

### DIFF
--- a/docker-compose.cms.yml
+++ b/docker-compose.cms.yml
@@ -11,7 +11,7 @@ services:
       PORT: 3001
       SESSION_DOMAIN: localhost
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
-      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/keystone
+      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/keystone?connect_timeout=10
       PORTAL_URL: http://localhost:3000
       REDIS_URL: redis://portal_redis:6379
     depends_on:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -51,13 +51,15 @@ services:
       PORT: 3001
       SESSION_SECRET: thisvaluecanbeanythingitisonlyforlocaldevelopment
       SESSION_DOMAIN: localhost
-      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/test
+      DATABASE_URL: postgres://keystone:keystonecms@keystone-db:5432/test?connect_timeout=10
       REDIS_URL: redis://portal_redis:6379
       PORTAL_URL: http://localhost:3000
     stdin_open: true
     depends_on:
-      - keystone-db
-      - redis
+      keystone-db:
+        condition: service_healthy
+      redis:
+        condition: service_started
 
   # Shared between CMS and Portal
   redis:
@@ -91,3 +93,8 @@ services:
       - POSTGRES_PASSWORD=keystonecms
       - POSTGRES_USER=keystone
       - POSTGRES_DB=test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=keystone --dbname=test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
# SC-1012

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

- extend the connection timeout from CMS App to Keystone DB from the default 5 seconds to 10 seconds
- add a health check to Keystone DB so CMS App waits until it is healthy in Docker Compose

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

This change only modifies how Docker Compose operates locally. In AWS, the connection string will have to be modified in AWS Systems Manager Parameter Store.

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed

