### PR TITLE
dev: Add dark mode styles for article pagination

### DIFF
--- a/src/components/ArticleList/ArticleList.module.scss
+++ b/src/components/ArticleList/ArticleList.module.scss
@@ -23,6 +23,8 @@ p.NoArticlesText {
   color: var(--text);
 }
 
+// TODO: Find a new place for these styles to live as the Pagination component could
+// potentially be used somewhere outside of ArticleList in the future.
 .pagination {
   :global {
     .usa-pagination__list {

--- a/src/components/ArticleList/ArticleList.module.scss
+++ b/src/components/ArticleList/ArticleList.module.scss
@@ -18,3 +18,29 @@
 * + .ArticleList {
   margin-top: units(5);
 }
+
+.pagination {
+  :global {
+    .usa-pagination__list {
+      > li.usa-pagination__item.usa-pagination__arrow > a {
+        > span {
+          color: var(--link-primary);
+        }
+
+        > svg {
+          color: var(--link-primary);
+        }
+      }
+
+      > li > a.usa-pagination__button {
+        background: transparent;
+        border: 1px solid var(--pagination-page-number-border);
+      }
+
+      > li > a.usa-pagination__button.usa-current {
+        background: var(--pagination-page-number-bg);
+        color: var(--pagination-page-number-active);
+      }
+    }
+  }
+}

--- a/src/components/ArticleList/ArticleList.module.scss
+++ b/src/components/ArticleList/ArticleList.module.scss
@@ -47,3 +47,4 @@ p.NoArticlesText {
       }
     }
   }
+}

--- a/src/components/ArticleList/ArticleList.tsx
+++ b/src/components/ArticleList/ArticleList.tsx
@@ -29,6 +29,7 @@ export const ArticleList = ({ articles, pagination }: ArticleListProps) => {
           pathname={window.location.pathname}
           totalPages={pagination.totalPages}
           currentPage={pagination.currentPage}
+          className={styles.pagination}
         />
       )}
     </>

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -164,7 +164,7 @@
   --form-input-placeholder: #{$theme-white};
 
   // Pagination
-  --pagination-page-number-bg: #{$white};
+  --pagination-page-number-bg: #{$theme-cosmiclatte-base};
   --pagination-page-number-border: #{$theme-spacebase-lighter};
   --pagination-page-number-active: #{$neutral-gray-900};
   --pagination-page-number-active-border: #{$theme-cosmiclatte-base};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -58,6 +58,12 @@
   --form-input-bg: transparent;
   --form-input-text: #{$theme-black};
   --form-input-border: #{color(base-light)};
+
+  // Pagination
+  --pagination-page-number-bg: #{$theme-ultraviolet-dark};
+  --pagination-page-number-border: #{$neutral-gray-300};
+  --pagination-page-number-active: #{$white};
+  --pagination-page-number-active-border: #{$neutral-gray-300};
 }
 
 /* ------------------------------------ */
@@ -112,6 +118,12 @@
   --form-input-text: #{$theme-white};
   --form-input-border: #{color(base-light)};
   --form-input-placeholder: #{$theme-white};
+
+  // Pagination
+  --pagination-page-number-bg: #{$white};
+  --pagination-page-number-border: #{$theme-spacebase-lighter};
+  --pagination-page-number-active: #{$neutral-gray-900};
+  --pagination-page-number-active-border: #{$theme-cosmiclatte-base};
 
   // Filters for SVG color changes
   // Generated using https://codepen.io/sosuke/pen/Pjoqqp

--- a/src/styles/sfds/_colors.scss
+++ b/src/styles/sfds/_colors.scss
@@ -86,6 +86,8 @@ $black: #000;
 $white: #fff;
 $grey: #f0f0f0;
 $neutral-gray: #767676;
+$neutral-gray-300: #cccccc;
+$neutral-gray-900: #262626;
 
 /** Taxonomy **/
 $tag-default-lighttheme: $theme-ultraviolet-base;


### PR DESCRIPTION
# SC-1025

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Adds dark mode support for the Pagination component.
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Since we're waiting for the `Pagination` component to be [merged into ReactUSWDS](https://github.com/trussworks/react-uswds/pull/2188), I thought I should keep the styles separate and NOT create an scss module for the component. With that being said, the only place that the `Pagination` component is currently being used is in the `ArticleList` component, so I added the necessary style updates there. 

Something else to note is that the dark mode toggle in Storybook does not work for `Pagination`. I'm not sure why that is the case, but I was thinking that once the `Pagination` component is merged into ReactUSWDS we'll most likely be removing the component and accompanying storybook stories from this codebase (correct me if I'm wrong in that assumption), so that's why I haven't spent any time to get that working.

In order to test the component, open any file that is using the `ArticleList` component:
- `news.tsx`
- `news-announcements.tsx`
- `orbit-blog.tsx`
- or any other instance you may happen upon

and pass it a `pagination` prop that looks like this:
`<ArticleList
        articles={articles}
       pagination={{ currentPage: 10, totalPages: 24 }}
      />`

Note: passing the `pagination` prop to `ArticleList` is just going to cause the `Pagination` component to render. Actual functionality of the component may vary.

Now navigate to wherever the `Pagination` component will be displayed and toggle between light and dark mode to verify that the styles match what you see in Figma.

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup
Make sure to have both the CMS and the portal client running on your local machine. You can do this by
- Running `yarn services:up && yarn dev` in the CMS repo and
- Running `yarn dev` in the portal client with this branch checked out

To toggle between light and dark mode, open the dev tools in your browser when running the portal, then click Application > Local Storage > Set a key/value pair for theme, dark.
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---