### PR TITLE
chore: Upgrade trim-newlines dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "trim": "0.0.3",
     "webpack": "5.73.0",
     "glob-parent": "6.0.2",
-    "parse-url": "8.1.0"
+    "parse-url": "8.1.0",
+    "trim-newlines": "3.0.1"
   },
   "browserslist": [
     "> 2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16857,12 +16857,7 @@ tree-kill@^1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==
-
-trim-newlines@^3.0.0:
+trim-newlines@3.1.0, trim-newlines@^1.0.0, trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==


### PR DESCRIPTION
# SC-1164

## Proposed changes
* Adds `trim-newlines` to `resolutions` to resolve dependency issue
* We can't update the parent package, `standard-version`, as it is now deprecated.

I've also created a chore (SC-1232) to migrate off `standard-version` in the future.

## Setup

To test that releasing still works, you can run `yarn release --dry-run` to see test output without actually creating a new release.

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Checked that the E2E test build is not failing


### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):



