### PR TITLE
chore: also scan typescript

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['javascript']
+        language: ['javascript', 'typescript']
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 


### PR DESCRIPTION
Per the [docs](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/) it seems like `typescript` might be separate from `javascript`. This tests that.