### PR TITLE
fix: adjusts button styling to be in alignment with Figma button styling

### DIFF
--- a/src/stories/buttons.stories.tsx
+++ b/src/stories/buttons.stories.tsx
@@ -117,32 +117,6 @@ export const Buttons = () => {
         Unstyled button
       </button>
 
-      <h3 className="site-preview-heading">Base color</h3>
-      <button type="button" className="usa-button usa-button--base">
-        Default
-      </button>
-      <button
-        type="button"
-        className="usa-button usa-button--base usa-button--hover">
-        Hover
-      </button>
-      <button
-        type="button"
-        className="usa-button usa-button--base usa-button--active">
-        Active
-      </button>
-      <button type="button" className="usa-button usa-button--base usa-focus">
-        Focus
-      </button>
-      <button type="button" className="usa-button usa-button--base" disabled>
-        Disabled
-      </button>
-      <button
-        type="button"
-        className="usa-button usa-button--base usa-button--unstyled">
-        Unstyled button
-      </button>
-
       <h3 className="site-preview-heading">Outline</h3>
       <button type="button" className="usa-button usa-button--outline">
         Default

--- a/src/stories/buttons.stories.tsx
+++ b/src/stories/buttons.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const Buttons = () => {
   return (
     <div className="sfds">
-      <h1>Buttons</h1>
+      <h2>Buttons</h2>
       <h3 className="site-preview-heading">Default</h3>
       <button type="button" className="usa-button">
         Default

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -29,6 +29,7 @@ $hero-image: url('/assets/images/hero.jpeg');
   --btn-primary-bg-hover: #{$theme-ultraviolet-dark};
   --btn-primary-bg-active: #{$theme-ultraviolet-darker};
 
+  --btn-secondary-text: #{$theme-white};
   --btn-secondary-bg: #{$theme-mars-base};
   --btn-secondary-bg-hover: #{$theme-mars-dark};
   --btn-secondary-bg-active: #{$theme-mars-darker};

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -195,6 +195,7 @@
 
   // Secondary
   .usa-button--secondary {
+    color: var(--btn-secondary-text);
     background-color: var(--btn-secondary-bg);
 
     &:hover,

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -222,7 +222,7 @@
     &:active,
     &.usa-button--active {
       color: $theme-white;
-      background-color: $theme-aurora-darker;
+      background-color: $theme-aurora-darkest;
     }
   }
 


### PR DESCRIPTION
# SC-1256
(related to [SC-1217 Catch all story for any remaining Dark Mode issues](https://app.shortcut.com/orbit-truss/story/1217/catch-all-story-for-any-remaining-dark-mode-issues) )

This branch adjusts colors in the accent and secondary buttons to be in alignment with our styles in Figma. This leads to some a11y color contrast failures going away 🥳

## Proposed changes

- adjusts text in secondary buttons to be white instead of the light grey we had
- adjusts background color of accent button to be `$theme-aurora-darkest` instead of `$theme-aurora-darker`, which also gets it's color contrast to be compliant
- removes base buttons - we don't seem to use them anywhere in the app code

## Reviewer notes

There are still color contrast failures on some of the buttons, because they also fail in the designs. I want to consult with Mallory so we can make a choice together on what we would like to adjust them to. These changes will come in a separate branch.

So far, it's looking like we will need to change either the background or text color on our secondary buttons.

## Setup

```
yarn storybook
```
http://localhost:6006/?path=/story/global-buttons--buttons 

---

## Screenshots

### Light Mode
<img width="848" alt="image" src="https://user-images.githubusercontent.com/59394696/196267990-feacb53e-0d48-4989-9e19-5b59fb28dd31.png">

### Dark Mode
<img width="849" alt="image" src="https://user-images.githubusercontent.com/59394696/196268304-f88e7ab0-4e05-4ce8-b970-cbf8bcaeff0c.png">

