### PR TITLE
fix: design: secondary buttons colors / more button design updates 

### DIFF
--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -32,8 +32,8 @@ $hero-image: url('/assets/images/hero.jpeg');
 
   --btn-secondary-text: #{$black};
   --btn-secondary-bg: #{$theme-mars-base};
-  --btn-secondary-bg-hover: #{$theme-mars-dark};
-  --btn-secondary-bg-active: #{$theme-mars-darker};
+  --btn-secondary-bg-hover: #{$theme-mars-darker};
+  --btn-secondary-bg-active: #{$theme-mars-darkest};
 
   --btn-outline-text: #{$theme-ultraviolet-base};
   --btn-outline-hover: #{$theme-ultraviolet-dark};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -30,7 +30,7 @@ $hero-image: url('/assets/images/hero.jpeg');
   --btn-primary-bg-hover: #{$theme-ultraviolet-dark};
   --btn-primary-bg-active: #{$theme-ultraviolet-darker};
 
-  --btn-secondary-text: #{$theme-white};
+  --btn-secondary-text: #{$black};
   --btn-secondary-bg: #{$theme-mars-base};
   --btn-secondary-bg-hover: #{$theme-mars-dark};
   --btn-secondary-bg-active: #{$theme-mars-darker};

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -169,6 +169,8 @@
   .usa-button {
     color: var(--btn-primary-text);
     background-color: var(--btn-primary-bg);
+    padding: 12px 24px;
+    font-family: 'Trebuchet MS', sans-serif;
 
     &:hover,
     &.usa-button--hover {


### PR DESCRIPTION
# SC-1281

this branch finishes up work to fix color contrast accessibility issues in the secondary buttons, and gets all buttons in alignment with styling in Figma.



## Proposed changes

- changes default color of secondary button text to black
- changes background color of hover and active states to be darker to meet 4:5:1 color contrast ratio required for AA accessibility compliance
- adds 4px of padding to the left and right of our buttons and sets font-family to Trebuchet 
- 🎉 buttons are now all passing color contrast tests and are fully compliant with WCAG 2.1 AA accessibility standards

## Reviewer Notes
If we get A LOT of Happo changes, that is expected! There are a couple of global button styling changes in this branch, and buttons are nested within many of our components. Make sure to look thorugh them carefully though to see if this change causes any layouts to degrade, as I would want to un-break anything before merge.

## Setup


    ```sh
    yarn storybook
    ```

go tot the `Buttons` page

## Screenshots

<img width="1627" alt="image" src="https://user-images.githubusercontent.com/59394696/197278323-6be1206a-32b0-4c15-b840-992316ef8e43.png">
