### PR TITLE
chore(deps): update amannn/action-semantic-pull-request action to v5 …

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lint pr title
-        uses: amannn/action-semantic-pull-request@536f681e2c60d973396eb60457d42ced8cd3f61a # tag=v3.7.0
+        uses: amannn/action-semantic-pull-request@01d5fd8a8ebb9aafe902c40c53f0f4744f7381eb # tag=v5.0.2
         with:
           wip: true
           types: |


### PR DESCRIPTION
Reapplies (#833)

This time the SHA of the updated action has been added to the list of approved actions.

Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>

