### PR TITLE
chore: resolve apollo-server-core@3.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "@opentelemetry/sdk-trace-node": "1.3.1",
     "@opentelemetry/tracing": "0.24.0",
     "@trussworks/react-uswds": "3.2.0",
-    "apollo-server-core": "3.11.0",
-    "apollo-server-micro": "3.10.2",
+    "apollo-server-core": "3.11.1",
+    "apollo-server-micro": "3.11.1",
     "axios": "0.27.2",
     "classnames": "2.3.1",
     "connect-redis": "6.1.3",
@@ -166,8 +166,7 @@
     "glob-parent": "6.0.2",
     "parse-url": "8.1.0",
     "trim-newlines": "3.0.1",
-    "@xmldom/xmldom": "0.8.4",
-    "apollo-server-core": "3.11.0"
+    "@xmldom/xmldom": "0.8.4"
   },
   "browserslist": [
     "> 2%",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,8 @@
     "glob-parent": "6.0.2",
     "parse-url": "8.1.0",
     "trim-newlines": "3.0.1",
-    "@xmldom/xmldom": "0.8.4"
+    "@xmldom/xmldom": "0.8.4",
+    "apollo-server-core": "3.11.0"
   },
   "browserslist": [
     "> 2%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,7 +5911,7 @@ apollo-reporting-protobuf@^3.3.1, apollo-reporting-protobuf@^3.3.3:
   dependencies:
     "@apollo/protobufjs" "1.2.6"
 
-apollo-server-core@3.11.0:
+apollo-server-core@3.11.0, apollo-server-core@^3.10.2:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.11.0.tgz#dbbf4c03ac0fdd8774e03c1f4f0d1ea1448b743c"
   integrity sha512-5iRlkbilXpQeY66/F2/t2oNO0YSqb+kFb5lyMUIqK9VLuBfI/hILQDa5H71ar7hhexKwoDzIDfSJRg5ASNmnQw==
@@ -5940,34 +5940,6 @@ apollo-server-core@3.11.0:
     uuid "^9.0.0"
     whatwg-mimetype "^3.0.0"
 
-apollo-server-core@^3.10.2:
-  version "3.10.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.10.3.tgz#64db45703785e9e79e7c5dadb6df2f7ee6fcbecc"
-  integrity sha512-PiTirlcaszgnJGzSsGui9XWh0KAh0BUW+GvRKN6O0H0qOSXSLmoqqyL83J+u+HaUZGyyiE0+VOkyCcuF+kKbEw==
-  dependencies:
-    "@apollo/utils.keyvaluecache" "^1.0.1"
-    "@apollo/utils.logger" "^1.0.0"
-    "@apollo/utils.usagereporting" "^1.0.0"
-    "@apollographql/apollo-tools" "^0.5.3"
-    "@apollographql/graphql-playground-html" "1.6.29"
-    "@graphql-tools/mock" "^8.1.2"
-    "@graphql-tools/schema" "^8.0.0"
-    "@josephg/resolvable" "^1.0.0"
-    apollo-datasource "^3.3.2"
-    apollo-reporting-protobuf "^3.3.3"
-    apollo-server-env "^4.2.1"
-    apollo-server-errors "^3.3.1"
-    apollo-server-plugin-base "^3.6.3"
-    apollo-server-types "^3.6.3"
-    async-retry "^1.2.1"
-    fast-json-stable-stringify "^2.1.0"
-    graphql-tag "^2.11.0"
-    loglevel "^1.6.8"
-    lru-cache "^6.0.0"
-    sha.js "^2.4.11"
-    uuid "^9.0.0"
-    whatwg-mimetype "^3.0.0"
-
 apollo-server-env@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-4.2.1.tgz#ea5b1944accdbdba311f179e4dfaeca482c20185"
@@ -5990,13 +5962,6 @@ apollo-server-micro@3.10.2:
     apollo-server-types "^3.6.2"
     type-is "^1.6.18"
 
-apollo-server-plugin-base@^3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.6.3.tgz#7eaf24af19641ddccf37307f294aba6877bf4c86"
-  integrity sha512-/Q0Zx8N8La97faKV0siGHDzfZ56ygN6ovtUpPbr+1GIbNmUzkte3lWW2YV08HmxiRmC2i2OGN80exNJEvbKvNA==
-  dependencies:
-    apollo-server-types "^3.6.3"
-
 apollo-server-plugin-base@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.0.tgz#b7170c2be0344d5f4382fea951f6d1dd274d6635"
@@ -6004,7 +5969,7 @@ apollo-server-plugin-base@^3.7.0:
   dependencies:
     apollo-server-types "^3.7.0"
 
-apollo-server-types@^3.6.2, apollo-server-types@^3.6.3:
+apollo-server-types@^3.6.2:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.6.3.tgz#7818cab914c865dafa53ea263ca6cb1854b4f05a"
   integrity sha512-+7caNTLdevpWI2dGKSa7CWdyudO3NBuJ3HzcrYxjBei6Bth9YdRUNzPSFmBjlm2baHF0GsrMwLpjO+HStJzm3A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5911,10 +5911,10 @@ apollo-reporting-protobuf@^3.3.1, apollo-reporting-protobuf@^3.3.3:
   dependencies:
     "@apollo/protobufjs" "1.2.6"
 
-apollo-server-core@3.11.0, apollo-server-core@^3.10.2:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.11.0.tgz#dbbf4c03ac0fdd8774e03c1f4f0d1ea1448b743c"
-  integrity sha512-5iRlkbilXpQeY66/F2/t2oNO0YSqb+kFb5lyMUIqK9VLuBfI/hILQDa5H71ar7hhexKwoDzIDfSJRg5ASNmnQw==
+apollo-server-core@3.11.1, apollo-server-core@^3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.11.1.tgz#89d83aeaa71a59f760ebfa35bb0cbd31e15474ca"
+  integrity sha512-t/eCKrRFK1lYZlc5pHD99iG7Np7CEm3SmbDiONA7fckR3EaB/pdsEdIkIwQ5QBBpT5JLp/nwvrZRVwhaWmaRvw==
   dependencies:
     "@apollo/utils.keyvaluecache" "^1.0.1"
     "@apollo/utils.logger" "^1.0.0"
@@ -5928,8 +5928,8 @@ apollo-server-core@3.11.0, apollo-server-core@^3.10.2:
     apollo-reporting-protobuf "^3.3.3"
     apollo-server-env "^4.2.1"
     apollo-server-errors "^3.3.1"
-    apollo-server-plugin-base "^3.7.0"
-    apollo-server-types "^3.7.0"
+    apollo-server-plugin-base "^3.7.1"
+    apollo-server-types "^3.7.1"
     async-retry "^1.2.1"
     fast-json-stable-stringify "^2.1.0"
     graphql-tag "^2.11.0"
@@ -5952,37 +5952,27 @@ apollo-server-errors@^3.3.0, apollo-server-errors@^3.3.1:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz#ba5c00cdaa33d4cbd09779f8cb6f47475d1cd655"
   integrity sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==
 
-apollo-server-micro@3.10.2:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/apollo-server-micro/-/apollo-server-micro-3.10.2.tgz#dc39f0b922b5339cad42f8e40e462e9d1077856c"
-  integrity sha512-A7aXwYt6/TdK44SWLsvxuJh13xbjNWGO7oNEWrP+x0pdvKh/BhQVM+L5ZueTmKtIQZ+F5w83OlIYbj6UH5vfGQ==
+apollo-server-micro@3.11.1:
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-micro/-/apollo-server-micro-3.11.1.tgz#4f1b7f68ce78c3f91f9a7cfbd1c1301f0d235ab7"
+  integrity sha512-4bETccnRotMQIg3ah4/NAWPppB05i5ePrTOuLBGBBQaV8bz1E4Md3snxSB8JkANND7sXmH9OCiKKeLFK8q8JaA==
   dependencies:
     "@hapi/accept" "^5.0.2"
-    apollo-server-core "^3.10.2"
-    apollo-server-types "^3.6.2"
+    apollo-server-core "^3.11.1"
+    apollo-server-types "^3.7.1"
     type-is "^1.6.18"
 
-apollo-server-plugin-base@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.0.tgz#b7170c2be0344d5f4382fea951f6d1dd274d6635"
-  integrity sha512-YRPjqFHvWK9eM4gN3D4ArrAtPY7Mb1FL+YoXXwq2GxdrsZSolnDYQkqZ6BhK11J8lUmAQpnpunK91IPZshWluA==
+apollo-server-plugin-base@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.7.1.tgz#aa78ef49bd114e35906ca9cf7493fed2664cbde8"
+  integrity sha512-g3vJStmQtQvjGI289UkLMfThmOEOddpVgHLHT2bNj0sCD/bbisj4xKbBHETqaURokteqSWyyd4RDTUe0wAUDNQ==
   dependencies:
-    apollo-server-types "^3.7.0"
+    apollo-server-types "^3.7.1"
 
-apollo-server-types@^3.6.2:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.6.3.tgz#7818cab914c865dafa53ea263ca6cb1854b4f05a"
-  integrity sha512-+7caNTLdevpWI2dGKSa7CWdyudO3NBuJ3HzcrYxjBei6Bth9YdRUNzPSFmBjlm2baHF0GsrMwLpjO+HStJzm3A==
-  dependencies:
-    "@apollo/utils.keyvaluecache" "^1.0.1"
-    "@apollo/utils.logger" "^1.0.0"
-    apollo-reporting-protobuf "^3.3.3"
-    apollo-server-env "^4.2.1"
-
-apollo-server-types@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.7.0.tgz#5a6f6f05a3c2ed937ad339b91665248dad957733"
-  integrity sha512-Y2wx7eH/dqqYDdzt0KBJRbVKR10bLiup2aT8huoBbp/u3nbCN88jo1yW+FvlETeV+iKuoY3RiZDlHIvcDQ5/lA==
+apollo-server-types@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.7.1.tgz#87adfcb52ec0893999a9cfafd5474bfda7ab0798"
+  integrity sha512-aE9RDVplmkaOj/OduNmGa+0a1B5RIWI0o3zC1zLvBTVWMKTpo0ifVf11TyMkLCY+T7cnZqVqwyShziOyC3FyUw==
   dependencies:
     "@apollo/utils.keyvaluecache" "^1.0.1"
     "@apollo/utils.logger" "^1.0.0"


### PR DESCRIPTION
This deals with [dependabot alert 54](https://github.com/USSF-ORBIT/ussf-portal-client/security/dependabot/54) and [Trivy scan result #89](https://github.com/USSF-ORBIT/ussf-portal-client/security/code-scanning/89)

#845 did not resolve the issue because apollo-server-micro was causing apollo-server-core to resolve to an earlier version. Both packages will be updated to 3.11.1.