### PR TITLE
build: add BUILD to build-args for build

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -57,6 +57,8 @@ jobs:
           load: true
           tags: ${{ secrets.C1_REGISTRY}}/${{ secrets.C1_REPOSITORY }}:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD=${{ github.sha }}
 
       - name: Push image to C1 Dev Artifactory
         id: push-c1-image


### PR DESCRIPTION
## Proposed changes

Add `BUILD` to build-args for deployment image build

## Reviewer notes

This will add the data needed to display `buildId` in `/api/sysinfo` call

## Setup

Deploy to staging?
