### PR TITLE
feat: Display hero image in article layout

### DIFF
--- a/src/components/SingleArticle/SingleArticle.module.scss
+++ b/src/components/SingleArticle/SingleArticle.module.scss
@@ -4,6 +4,12 @@
   margin-top: units(6);
   margin-bottom: units(4);
 
+  .hero {
+    width: 100%;
+    max-height: 340px;
+    object-fit: cover;
+  }
+
   h2 {
     margin-bottom: 0;
   }

--- a/src/components/SingleArticle/SingleArticle.module.scss
+++ b/src/components/SingleArticle/SingleArticle.module.scss
@@ -4,6 +4,8 @@
   margin-top: units(6);
   margin-bottom: units(4);
 
+  max-width: 948px;
+
   .hero {
     width: 100%;
     max-height: 340px;

--- a/src/components/SingleArticle/SingleArticle.module.scss
+++ b/src/components/SingleArticle/SingleArticle.module.scss
@@ -13,7 +13,7 @@
   }
 
   h2 {
-    margin-bottom: 0;
+    margin-bottom: units(2);
   }
 
   h2 + .metadata {

--- a/src/components/SingleArticle/SingleArticle.stories.tsx
+++ b/src/components/SingleArticle/SingleArticle.stories.tsx
@@ -170,3 +170,11 @@ const testArticle = {
 export const ExampleSingleArticle = () => (
   <SingleArticle article={testArticle} />
 )
+
+const articleWithHero = {
+  ...testArticle,
+  hero: { url: '/assets/images/hero.jpeg' },
+}
+export const ExampleSingleArticleWithHero = () => (
+  <SingleArticle article={articleWithHero} />
+)

--- a/src/components/SingleArticle/SingleArticle.test.tsx
+++ b/src/components/SingleArticle/SingleArticle.test.tsx
@@ -181,11 +181,11 @@ describe('SingleArticle component', () => {
     expect(img).toHaveClass('hero')
   })
 
-  test('does not render an img tag if article has no hero url', async () => {
-    const noHero = { ...testArticle, hero: { url: undefined } }
+  test('does not render an img tag if article has no hero url', () => {
+    const noHero = { ...testArticle, hero: undefined }
     render(<SingleArticle article={noHero} />)
 
-    const img = await screen.queryByRole('img', {
+    const img = screen.queryByRole('img', {
       name: 'article hero graphic',
     })
     expect(img).not.toBeInTheDocument()

--- a/src/components/SingleArticle/SingleArticle.test.tsx
+++ b/src/components/SingleArticle/SingleArticle.test.tsx
@@ -15,7 +15,7 @@ const testArticle = {
   category: 'InternalNews',
   publishedDate: '2022-05-17T13:44:39.796Z',
   hero: {
-    url: '',
+    url: 'http://cms.example.com/images/image.png',
   },
   body: {
     document: [
@@ -160,12 +160,24 @@ const testArticle = {
 }
 
 describe('SingleArticle component', () => {
-  it('renders the article', () => {
+  test('renders the article', () => {
     render(<SingleArticle article={testArticle} />)
 
     expect(screen.getByText('May 17, 2022')).toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
       testArticle.title
     )
+  })
+
+  test("renders the article's hero image", () => {
+    render(<SingleArticle article={testArticle} />)
+
+    const img = screen.getByRole('img', { name: 'article hero graphic' })
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute('src')
+    expect(img.getAttribute('src')).toEqual(
+      'http://cms.example.com/images/image.png'
+    )
+    expect(img).toHaveClass('hero')
   })
 })

--- a/src/components/SingleArticle/SingleArticle.test.tsx
+++ b/src/components/SingleArticle/SingleArticle.test.tsx
@@ -180,4 +180,14 @@ describe('SingleArticle component', () => {
     )
     expect(img).toHaveClass('hero')
   })
+
+  test('does not render an img tag if article has no hero url', async () => {
+    const noHero = { ...testArticle, hero: { url: undefined } }
+    render(<SingleArticle article={noHero} />)
+
+    const img = await screen.queryByRole('img', {
+      name: 'article hero graphic',
+    })
+    expect(img).not.toBeInTheDocument()
+  })
 })

--- a/src/components/SingleArticle/SingleArticle.tsx
+++ b/src/components/SingleArticle/SingleArticle.tsx
@@ -28,17 +28,16 @@ export const SingleArticle = ({ article }: { article: ArticleRecord }) => {
   })
   const publishedDateObj = new Date(publishedDate)
 
-  let heroImg = null
-  if (hero?.url && hero.url !== '') {
-    heroImg = (
-      <img src={hero.url} alt="article hero graphic" className={styles.hero} />
-    )
-  }
-
   return (
     <article className={styles.SingleArticle}>
       <div>
-        {heroImg}
+        {hero && (
+          <img
+            src={hero.url}
+            alt="article hero graphic"
+            className={styles.hero}
+          />
+        )}
         <h2>{title}</h2>
         <div className={styles.tagAndLabelContainer}>
           {category === 'InternalNews' ? (

--- a/src/components/SingleArticle/SingleArticle.tsx
+++ b/src/components/SingleArticle/SingleArticle.tsx
@@ -39,6 +39,7 @@ export const SingleArticle = ({ article }: { article: ArticleRecord }) => {
     <article className={styles.SingleArticle}>
       <div>
         {heroImg}
+        <h2>{title}</h2>
         <div className={styles.tagAndLabelContainer}>
           {category === 'InternalNews' ? (
             <Category category={CONTENT_CATEGORIES.INTERNAL_NEWS} />
@@ -64,8 +65,6 @@ export const SingleArticle = ({ article }: { article: ArticleRecord }) => {
               )
             })}
         </div>
-
-        <h2>{title}</h2>
 
         <dl className={styles.metadata}>
           <div>

--- a/src/components/SingleArticle/SingleArticle.tsx
+++ b/src/components/SingleArticle/SingleArticle.tsx
@@ -27,10 +27,18 @@ export const SingleArticle = ({ article }: { article: ArticleRecord }) => {
     day: '2-digit',
   })
   const publishedDateObj = new Date(publishedDate)
+
+  let heroImg = null
+  if (hero?.url && hero.url !== '') {
+    heroImg = (
+      <img src={hero.url} alt="article hero graphic" className={styles.hero} />
+    )
+  }
+
   return (
     <article className={styles.SingleArticle}>
       <div>
-        <img src={url} alt="article hero graphic" className={styles.hero} />
+        {heroImg}
         <div className={styles.tagAndLabelContainer}>
           {category === 'InternalNews' ? (
             <Category category={CONTENT_CATEGORIES.INTERNAL_NEWS} />

--- a/src/components/SingleArticle/SingleArticle.tsx
+++ b/src/components/SingleArticle/SingleArticle.tsx
@@ -30,6 +30,7 @@ export const SingleArticle = ({ article }: { article: ArticleRecord }) => {
   return (
     <article className={styles.SingleArticle}>
       <div>
+        <img src={url} alt="article hero graphic" className={styles.hero} />
         <div className={styles.tagAndLabelContainer}>
           {category === 'InternalNews' ? (
             <Category category={CONTENT_CATEGORIES.INTERNAL_NEWS} />

--- a/src/pages/about-us/orbit-blog.tsx
+++ b/src/pages/about-us/orbit-blog.tsx
@@ -23,7 +23,7 @@ const PortalNews = ({
   return !user ? (
     <Loader />
   ) : (
-    <div>
+    <div className={styles.listContainer}>
       <div className={styles.pageTitle}>
         <h2>Production team blog & announcements</h2>
         <h3>

--- a/src/pages/news-announcements.tsx
+++ b/src/pages/news-announcements.tsx
@@ -37,7 +37,7 @@ const NewsAnnouncements = ({
   return !user ? (
     <Loader />
   ) : (
-    <div>
+    <div className={styles.listContainer}>
       {announcements.length > 0 && (
         <section>
           <Announcement announcements={announcements} />

--- a/src/styles/pages/news.module.scss
+++ b/src/styles/pages/news.module.scss
@@ -1,6 +1,10 @@
 @import 'styles/uswdsDependencies';
 @import 'styles/sfds/sfdsDependencies';
 
+.listContainer {
+  max-width: 1220px;
+}
+
 .pageTitle {
   margin-top: units(6);
   margin-bottom: units(4);


### PR DESCRIPTION
# SC-901

## Proposed changes

This PR is based on #862 and USSF-ORBIT/ussf-portal-cms#98. It will need to be merged in after both of them.

The aforementioned PRs add support to upload a hero image for an article and return it in the article data. This PR modifies the `SingleArticle` component to display the hero image.

In addition to the css changes needed for the hero image this PR adds a `max-width` attribute to the SingleArticle component and the 2 article lists `orbit blog` and `news and announcements` pages.

Also the labels for an article moved to below the title as in the latest figma design.

## Reviewer notes

I set the `max-width` of the article to `948px` as in figma. That width looked a bit too small for the article lists. I looked in figma and those were wider, so I picked the `1220px` that I found for the `news and announcements` page in figma. Please let me know if that's not correct or if it would be better with some other definition. 

Also I wasn't sure if there were grid classes that would do the same thing, let me know if there are.

## Setup

- `yarn services:up`
- `yarn dev` in the cms repo
  - NOTE This needs to include the hero image code from https://github.com/USSF-ORBIT/ussf-portal-cms/pull/98
- `yarn dev` in this repo
- Create an article that has a hero image for orbit blog and internal news
- View the pages to ensure image shows up and has `max-width`
- Add an article with no hero image should still work.

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

### Orbit Blog Article
![Screenshot 2022-12-08 at 15 51 57](https://user-images.githubusercontent.com/940173/206594570-fc38b726-fc29-49b3-86b1-2b8d935d63bd.png)

### Orbit Blog Article List
![Screenshot 2022-12-08 at 15 51 16](https://user-images.githubusercontent.com/940173/206594551-ce4ac600-8e61-4d8f-b2dc-b002fe5b6135.png)

### Internal News Article
![Screenshot 2022-12-08 at 15 52 48](https://user-images.githubusercontent.com/940173/206594602-fbefcf26-1256-4640-ab15-e4a58fcccac6.png)

### Internal News Article List
![Screenshot 2022-12-08 at 15 52 38](https://user-images.githubusercontent.com/940173/206594596-e3c158ba-81ef-47a7-9a27-dd5822fc24c5.png)
