### PR TITLE
build: switch CODEOWNERS to use group code-owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default owners for everything
 
-* @abbyoung @esacteksab @gidjin @minhlai
+* @USSF-ORBIT/code-owners
 
 # Require design / frontend reviews on Storybook
 
@@ -9,7 +9,7 @@
 
 # Github settings
 
-.github/settings.yml @abbyoung @esacteksab @gidjin @minhlai
+.github/settings.yml @USSF-ORBIT/code-owners
 
 # CODEOWNERS prevent renovate automerge since it will automatically ask for review
 


### PR DESCRIPTION
# SC-1348

Also resolves SC-1349

## Proposed changes

Instead of creating a PR to add or remove code owners this adds a github group to manage the same thing.

## Reviewer notes

I've created PRs for this in the portal (this pr), client (USSF-ORBIT/ussf-portal-client#902), and cms (USSF-ORBIT/ussf-portal-cms#234) repos.