### PR TITLE
feat: design: storybook: adds featured shortcuts to storybook and styles for dark mode

### DIFF
--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
@@ -7,6 +7,7 @@
   }
   :global(h3) {
     font-family: $sfds-heading-font;
+    color: var(--text);
   }
 }
 

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
@@ -48,6 +48,7 @@
         &:hover,
         &:focus {
           background: var(--shortcut-hover-bg);
+          border-radius: 4px;
         }
       }
     }

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
@@ -24,7 +24,7 @@
 
     font-weight: 500;
     list-style-type: none;
-    border: 1px solid var(--widget-border);
+    border: 1px solid var(--shortcut-border);
     border-radius: 4px;
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
     background-color: var(--widget-bg);

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
@@ -5,6 +5,9 @@
   :global(.grid-row.grid-gap) {
     margin: 22px 0 0;
   }
+  :global(h3) {
+    font-family: $sfds-heading-font;
+  }
 }
 
 .featuredShortcutsRow {

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.module.scss
@@ -18,14 +18,12 @@
     height: 100px;
     margin: 6px;
     flex-grow: 1;
-
     font-size: 22px;
     line-height: normal;
     @include heading-book;
+
     font-weight: 500;
-
     list-style-type: none;
-
     border: 1px solid var(--widget-border);
     border-radius: 4px;
     box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.15);
@@ -42,8 +40,14 @@
         align-items: center;
         height: 100%;
         width: 100%;
+        color: var(--text);
+        &:hover,
+        &:focus {
+          background: var(--shortcut-hover-bg);
+        }
       }
     }
+
     @media (max-width: 1550px) {
       font-size: 18px;
       height: 76px;

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
@@ -1,13 +1,31 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
+import { ObjectId } from 'bson'
 import FeaturedShortcuts from './FeaturedShorcuts'
 import { featuredShortcutItems } from './FeaturedShortcutItems'
+import { Widget } from 'types/index'
+
+const mockFeaturedShortcutsWidget: Widget = {
+  _id: new ObjectId(),
+  title: 'Featured Shortcuts',
+  type: 'FeaturedShortcuts',
+}
 
 export default {
   title: 'Components/Widgets/FeaturedShortcuts',
   component: FeaturedShortcuts,
+  decorators: [
+    (Story) => (
+      <div className="sfds">
+        <Story />
+      </div>
+    ),
+  ],
 } as Meta
 
 export const FeaturedShorcutsWidget = () => (
-  <FeaturedShortcuts featuredShortcuts={featuredShortcutItems} widget />
+  <FeaturedShortcuts
+    featuredShortcuts={featuredShortcutItems}
+    widget={mockFeaturedShortcutsWidget}
+  />
 )

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import FeaturedShortcuts from './FeaturedShorcuts'
+import { featuredShortcutItems } from 'components/FeaturedShortcuts/FeaturedShortcutItems'
+
+export default {
+  title: 'Components/Widgets/FeaturedShortcuts',
+  component: FeaturedShortcuts,
+} as Meta
+
+export const FeaturedShorcutsWidget = () => (
+  <FeaturedShortcuts featuredShortcuts={featuredShortcutItems} />
+)

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
 import FeaturedShortcuts from './FeaturedShorcuts'
-import { featuredShortcutItems } from 'components/FeaturedShortcuts/FeaturedShortcutItems'
+import { featuredShortcutItems } from './FeaturedShortcutItems'
 
 export default {
   title: 'Components/Widgets/FeaturedShortcuts',
@@ -9,5 +9,5 @@ export default {
 } as Meta
 
 export const FeaturedShorcutsWidget = () => (
-  <FeaturedShortcuts featuredShortcuts={featuredShortcutItems} />
+  <FeaturedShortcuts featuredShortcuts={featuredShortcutItems} widget />
 )

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -151,6 +151,9 @@ $dark-gradient: linear-gradient(
   --btn-box-border: #{$neutral-gray};
   --date-icon-bg: #{$theme-cosmiclatte-lighter};
 
+  //Featured Shortcuts
+  --shortcut-hover-bg: #{$grey};
+
   // Tags
   --tag-source-bg: #{$label-source-lighttheme-bg};
   --tag-source-text: #{$white};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -153,6 +153,7 @@ $dark-gradient: linear-gradient(
 
   //Featured Shortcuts
   --shortcut-hover-bg: #{$grey};
+  --shortcut-border: var(--widget-border);
 
   // Tags
   --tag-source-bg: #{$label-source-lighttheme-bg};
@@ -329,6 +330,10 @@ $dark-gradient: linear-gradient(
   --btn-box-bg: #{$theme-spacebase-light};
   --btn-box-border: #{$neutral-gray-800};
   --date-icon-bg: #{$theme-cosmiclatte-lightest};
+
+  //Featured Shortcuts
+  --shortcut-hover-bg: #{$theme-ultraviolet-darkest};
+  --shortcut-border: #{$theme-aurora-base};
 
   // Tags
   --tag-source-bg: #{$label-source-darktheme-bg};


### PR DESCRIPTION
# SC-1715

## Proposed changes

This branch adds in featued shortcuts component to stroybook and also does dark mode styling, adds in theme variables for featured shortcut items

## Reviewer notes



## Setup

    ```sh
    yarn storybook
    ```
[http://localhost:6006/?path=/story/components-widgets-featuredshortcuts--featured-shorcuts-widget](http://localhost:6006/?path=/story/components-widgets-featuredshortcuts--featured-shorcuts-widget )

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [x] Created new stories in Storybook if applicable
  - [x] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [x] Checked responsiveness in mobile, tablet, and desktop
  - [x] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [x] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots
![Screen Shot 2023-03-22 at 15 27 39](https://user-images.githubusercontent.com/59394696/227015327-2c3fa5a5-ca69-4d3e-b440-bb355d7da951.png)
![Screen Shot 2023-03-22 at 15 27 43](https://user-images.githubusercontent.com/59394696/227015336-082b5252-802d-4e69-9734-b8989a4fc9f1.png)

