### PR TITLE
dev: Additional event tracking for featured shortcuts

### DIFF
--- a/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
@@ -67,7 +67,8 @@ const FeaturedShortcuts = ({
               <LinkTo
                 href={a.url}
                 target="_blank"
-                onClick={() => handleEventTracking(a.title)}>
+                onClick={() => handleEventTracking(a.title)}
+                data-testid="featured-shortcut-link">
                 <img src={a.icon} alt="" />
                 {a.title}
               </LinkTo>

--- a/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
@@ -5,6 +5,7 @@ import type { Widget, featuredShortcutItems } from 'types'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 import { WidgetWithSettings } from 'components/Widget/Widget'
 import { useModalContext } from 'stores/modalContext'
+import { useAnalytics } from 'stores/analyticsContext'
 
 const FeaturedShortcuts = ({
   featuredShortcuts,
@@ -15,6 +16,7 @@ const FeaturedShortcuts = ({
 }) => {
   const { updateModalId, updateModalText, modalRef, updateWidget } =
     useModalContext()
+  const { trackEvent } = useAnalytics()
 
   const handleConfirmRemoveSection = () => {
     updateModalId('removeFeaturedShortcutsSectionModal')
@@ -35,6 +37,15 @@ const FeaturedShortcuts = ({
     modalRef?.current?.toggleModal(undefined, true)
   }
 
+  const handleEventTracking = (clickedShortcut) => {
+    trackEvent(
+      'Featured Shortcuts',
+      'Click on a featured shortcut',
+      'Click icon',
+      clickedShortcut.title
+    )
+  }
+
   return (
     <WidgetWithSettings
       header={<h3>Featured Shortcuts</h3>}
@@ -53,7 +64,10 @@ const FeaturedShortcuts = ({
             <li
               key={'widget_shortcut_' + a.title}
               className={styles.featuredShortcutsItem}>
-              <LinkTo href={a.url} target="_blank">
+              <LinkTo
+                href={a.url}
+                target="_blank"
+                onClick={() => handleEventTracking(a)}>
                 <img src={a.icon} alt="" />
                 {a.title}
               </LinkTo>

--- a/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
@@ -37,12 +37,12 @@ const FeaturedShortcuts = ({
     modalRef?.current?.toggleModal(undefined, true)
   }
 
-  const handleEventTracking = (clickedShortcut) => {
+  const handleEventTracking = (clickedShortcutTitle: string) => {
     trackEvent(
       'Featured Shortcuts',
       'Click on a featured shortcut',
       'Click icon',
-      clickedShortcut.title
+      clickedShortcutTitle
     )
   }
 
@@ -67,7 +67,7 @@ const FeaturedShortcuts = ({
               <LinkTo
                 href={a.url}
                 target="_blank"
-                onClick={() => handleEventTracking(a)}>
+                onClick={() => handleEventTracking(a.title)}>
                 <img src={a.icon} alt="" />
                 {a.title}
               </LinkTo>

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
@@ -11,6 +11,7 @@ import { renderWithModalRoot } from '../../testHelpers'
 import FeaturedShortcuts from './FeaturedShorcuts'
 import { featuredShortcutItems } from './FeaturedShortcutItems'
 import { Widget } from 'types/index'
+import * as analyticsHooks from 'stores/analyticsContext'
 
 const mockFeaturedShortcutsWidget: Widget = {
   _id: ObjectId(),
@@ -69,5 +70,34 @@ describe('FeaturedShortcuts component', () => {
         'You can re-add it to your My Space from the Add Section menu.',
     })
     expect(mockUpdateWidget).toHaveBeenCalled()
+  })
+
+  test('calls trackEvent when a shortcut is clicked', async () => {
+    const user = userEvent.setup()
+    const mockTrackEvents = jest.fn()
+
+    jest.spyOn(analyticsHooks, 'useAnalytics').mockImplementation(() => {
+      return { push: jest.fn(), trackEvent: mockTrackEvents }
+    })
+
+    render(
+      <FeaturedShortcuts
+        featuredShortcuts={featuredShortcutItems}
+        widget={mockFeaturedShortcutsWidget}
+      />
+    )
+
+    // Click the first featured shortcut - these values are currently static and
+    // placed in the file FeaturedShortcutItems.ts
+    const featuredShortcuts = screen.getAllByTestId('featured-shortcut-link')
+    await user.click(featuredShortcuts[0])
+
+    expect(mockTrackEvents).toHaveBeenCalledTimes(1)
+    expect(mockTrackEvents).toHaveBeenCalledWith(
+      'Featured Shortcuts',
+      'Click on a featured shortcut',
+      'Click icon',
+      'Webmail'
+    )
   })
 })

--- a/src/stores/analyticsContext.tsx
+++ b/src/stores/analyticsContext.tsx
@@ -13,7 +13,7 @@ type TrackFn = (
   category: string,
   action: string,
   name?: string | undefined,
-  value?: number | undefined
+  value?: number | string | undefined
 ) => void
 
 export type AnalyticsContextType = {
@@ -67,7 +67,7 @@ export const AnalyticsProvider = ({
     category: string,
     action: string,
     name?: string,
-    value?: number
+    value?: number | string
   ): void => {
     const pushParams: PushArgs = ['trackEvent', category, action]
     if (name !== undefined) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -200,11 +200,13 @@ export type MySpaceWidget = Widget | Collection
 export type MySpace = MySpaceWidget[]
 
 /* Featured Shortcut Items represents items appearing in Featured Shortcuts widget */
-export type featuredShortcutItems = {
+export type featuredShortcutItem = {
   title: string
   icon: string
   url: string
-}[]
+}
+
+export type featuredShortcutItems = featuredShortcutItem[]
 
 /**
  * ***********************


### PR DESCRIPTION
# SC-1676

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Adds additional event tracking for when a user clicks on a featured shortcut
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
A couple of ways to test:
- Run the app locally, click a featured shortcut, and check your browser console to see if the event fired
- Push this branch to the dev environment, login to Matomo on dev, and verify that the events fire as expected
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup
Run the client as usual. The CMS can run on main:

- In the CMS repo `yarn services:up && yarn dev`
- In the portal `yarn dev`
<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
