### PR TITLE
ci: allow storybook deploy workflow be manually triggered

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -6,6 +6,7 @@ on:
       - 'docs/**'
       - '**.md**'
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   deploy-storybook:


### PR DESCRIPTION
# SC-1316

## Proposed changes

To allow testing of workflow changes via `gh` cli enable workflow trigger for storybook deploy workflow.

## Reviewer notes

## Setup

None, once merged we will be able to trigger the flow manually