### PR TITLE
ci: allow ci build node-ci to be triggered manually

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,6 +11,7 @@ on:
       - 'docs/**'
       - '**.md**'
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   lint-and-test:


### PR DESCRIPTION
# SC-1316

## Proposed changes

To better support experimenting with our workflow adding a manual trigger to node-ci workflow file. I want to see if we can save the storybook artifact built by happo testing process to reuse when deploying storybook.