### PR TITLE
fix: design: storybook: link color adjustments and storybook documentation

### DIFF
--- a/src/components/NewsItem/NewsItem.module.scss
+++ b/src/components/NewsItem/NewsItem.module.scss
@@ -92,6 +92,7 @@ a.articleLink {
 
 .articleTag {
   align-self: flex-start;
+  color: $black;
 }
 
 .newsWidgetItem {

--- a/src/components/NewsItem/NewsItem.tsx
+++ b/src/components/NewsItem/NewsItem.tsx
@@ -38,7 +38,9 @@ const NewsItem = ({
         </span>
       </p>
 
-      <Tag className={styles.articleTag} background={colors['theme-mars-base']}>
+      <Tag
+        className={styles.articleTag}
+        background={colors['theme-mars-light']}>
         {sourceName}
       </Tag>
     </article>

--- a/src/stories/type.stories.tsx
+++ b/src/stories/type.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Meta } from '@storybook/react'
+import { background } from '@storybook/theming'
 
 export default {
   title: 'Global/Typography',
@@ -243,6 +244,35 @@ export const Links = () => {
             a text link
           </a>{' '}
           on a light background.
+        </p>
+
+        <p>
+          This is{' '}
+          <a
+            className="usa-link usa-color-text-visited"
+            href="javascript:void(0);">
+            a visited link
+          </a>
+          .
+        </p>
+
+        <p>
+          This is a link that goes to an{' '}
+          <a
+            className="usa-link usa-link--external"
+            href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">
+            external website
+          </a>
+          .
+        </p>
+      </section>
+      <section className="usa-dark-background">
+        <p>
+          This is{' '}
+          <a className="usa-link" href="javascript:void(0);">
+            a text link
+          </a>{' '}
+          on a dark background.
         </p>
 
         <p>

--- a/src/stories/type.stories.tsx
+++ b/src/stories/type.stories.tsx
@@ -237,36 +237,38 @@ export const Links = () => {
   return (
     <div className="sfds">
       <section>
-        <h1>Links</h1>
-        <p>
-          This is{' '}
-          <a className="usa-link" href="javascript:void(0);">
-            a text link
-          </a>{' '}
-          on a light background.
-        </p>
+        <h1 className="padding-left-2">Links</h1>
+        <div className="padding-2 padding-top-0">
+          <p>
+            This is{' '}
+            <a className="usa-link" href="javascript:void(0);">
+              a text link
+            </a>{' '}
+            on a standard background.
+          </p>
 
-        <p>
-          This is{' '}
-          <a
-            className="usa-link usa-color-text-visited"
-            href="javascript:void(0);">
-            a visited link
-          </a>
-          .
-        </p>
+          <p>
+            This is{' '}
+            <a
+              className="usa-link usa-color-text-visited"
+              href="javascript:void(0);">
+              a visited link
+            </a>
+            .
+          </p>
 
-        <p>
-          This is a link that goes to an{' '}
-          <a
-            className="usa-link usa-link--external"
-            href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">
-            external website
-          </a>
-          .
-        </p>
+          <p>
+            This is a link that goes to an{' '}
+            <a
+              className="usa-link usa-link--external"
+              href="https://i.giphy.com/media/WPzQF6ruiIIVzHNlwX/source.gif">
+              external website
+            </a>
+            .
+          </p>
+        </div>
       </section>
-      <section className="usa-dark-background">
+      <section className="usa-dark-background padding-2">
         <p>
           This is{' '}
           <a className="usa-link" href="javascript:void(0);">

--- a/src/styles/_govBanner.scss
+++ b/src/styles/_govBanner.scss
@@ -4,7 +4,7 @@
     $site-banner-icon-color: 'blue-40v';
     $site-banner-font-family: 'sans';
     $site-banner-max-width: 'none';
-    $site-banner-link-color: 'base-light';
+    $site-banner-link-color: 'orange-warm-10v';
 
     $banner-icon-colors: get-link-tokens-from-bg(
       $site-banner-bg,

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -75,7 +75,7 @@ $dark-gradient: linear-gradient(
   --btn-theme-toggle-bg: #{$theme-ultraviolet-base};
   --btn-theme-toggle-text: #{$white};
   --btn-logout-primary-bg: #{$theme-mars-base};
-  --btn-logout-text: #{$white};
+  --btn-logout-text: #{$black};
   --btn-logout-hover: #{$theme-mars-dark};
 
   --btn-delete-text: #{$state-error-base};
@@ -263,7 +263,7 @@ $dark-gradient: linear-gradient(
   --btn-add-widget-icon-hover: #{$theme-spacebase-light};
 
   --btn-logout-primary-bg: #{$theme-mars-base};
-  --btn-logout-text: #{$white};
+  --btn-logout-text: #{$black};
   --btn-logout-hover: #{$theme-mars-dark};
 
   --btn-add-widget-border: #{$theme-spacebase-dark};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -195,6 +195,10 @@ $dark-gradient: linear-gradient(
   --breadcrumbs-link-hover: var(--link-primary);
   --breadcrumbs-edit-display-name: var(--link-primary);
 
+  // Dark bg links
+  --dark-bg-link: #{$theme-aurora-light};
+  --dark-bg-link-hover: #{$white};
+
   // Accordion
   --accordion-title: #1b1b1b;
   --accordion-btn-bg: #{$grey};
@@ -407,6 +411,10 @@ $dark-gradient: linear-gradient(
   --breadcrumbs-link: #{$theme-mars-light};
   --breadcrumbs-link-hover: #{$white};
   --breadcrumbs-edit-display-name: #{$theme-mars-light};
+
+  // Dark bg links
+  --dark-bg-link: #{$theme-aurora-light};
+  --dark-bg-link-hover: #{$white};
 
   // Footer
   --footer-bg: #{$black};

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -150,9 +150,10 @@
     }
 
     a {
-      color: var(--breadcrumbs-link);
-      &:hover {
-        color: var(--breadcrumbs-link-hover);
+      color: var(--dark-bg-link);
+      &:hover,
+      &:focus {
+        color: var(--dark-bg-hover);
       }
     }
 


### PR DESCRIPTION
# SC-1560
# SC-1644

## Proposed changes

This branch adjusts the dark background base link styles and ensures it is [displayed correctly in storybook](http://localhost:6006/?path=/story/global-typography--links). 

This branch also adjusts link colors that were catching color contrast violations on a few components including:
- the [logout button](http://localhost:6006/?path=/story/navigation-header--default-header) (this also aligns it to what we have in figma) -> text changed from white to black
- the [news item tag ](http://localhost:6006/?path=/story/components-newswidget-newsitem--rss-article)(i know its design is going to change but in the meantime i aligned it more to what its changing to) -> text color darkened and background lightened
- the 'Here's how you know' link in the gov banner. this actually turned out to be compliant but we thought it was just hard to read so why not improve it. 


## Setup

```
yarn storybook
```
http://localhost:6006/?path=/story/global-typography--links
http://localhost:6006/?path=/story/components-newswidget-newsitem--rss-article
http://localhost:6006/?path=/story/navigation-header--default-header

## Screenshots

![Screen Shot 2023-03-28 at 14 24 11](https://user-images.githubusercontent.com/59394696/228333974-f2f5d9d0-5e45-48a5-927f-1b6346852d39.png)

![Screen Shot 2023-03-28 at 14 24 07](https://user-images.githubusercontent.com/59394696/228333979-97033c65-d2d2-4c6f-9103-126a3867b0cc.png)

<img width="350" alt="image" src="https://user-images.githubusercontent.com/59394696/228334025-b19ef394-433d-4617-a40c-f08d7a901cc3.png">

<img width="411" alt="image" src="https://user-images.githubusercontent.com/59394696/228334123-c98b97f1-933e-4182-a6ba-2af754d9432a.png">

<img width="376" alt="image" src="https://user-images.githubusercontent.com/59394696/228334217-a4ccecd1-93fa-4956-80d9-46ce173a0701.png">

