### PR TITLE
chore: Add migration for featured shortcuts default widget

### DIFF
--- a/migrations/1679951734168-add-featured-shortcuts-widget.js
+++ b/migrations/1679951734168-add-featured-shortcuts-widget.js
@@ -1,0 +1,50 @@
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { runMigration } = require('../utils/mongodb')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { ObjectId } = require('mongodb')
+
+module.exports.up = runMigration(async (db) => {
+  // If the first item in a user's MySpace is not FeaturedShortcuts, add it.
+  // `default: true` lets us know we've added it as a default and not the user.
+  await db.collection('users').updateMany(
+    {
+      'mySpace.0.type': {
+        $ne: 'FeaturedShortcuts',
+      },
+    },
+    {
+      $push: {
+        mySpace: {
+          $each: [
+            {
+              _id: new ObjectId(),
+              title: 'Featured Shortcuts',
+              type: 'FeaturedShortcuts',
+              default: true,
+            },
+          ],
+          $position: 0,
+        },
+      },
+    }
+  )
+})
+
+module.exports.down = runMigration(async (db) => {
+  await db.collection('users').updateMany(
+    {
+      'mySpace.0.type': {
+        $eq: 'FeaturedShortcuts',
+      },
+      'mySpace.0.default': true,
+    },
+
+    {
+      $pop: {
+        mySpace: -1,
+      },
+    }
+  )
+})

--- a/migrations/1679951734168-add-featured-shortcuts-widget.js
+++ b/migrations/1679951734168-add-featured-shortcuts-widget.js
@@ -1,9 +1,9 @@
 'use strict'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { runMigration } = require('../utils/mongodb')
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { ObjectId } = require('mongodb')
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { runMigration } = require('../utils/mongodb')
 
 module.exports.up = runMigration(async (db) => {
   // If the first item in a user's MySpace is not FeaturedShortcuts, add it.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -168,6 +168,8 @@ export type Widget = {
   _id: ObjectId
   title: string
   type: WidgetType
+  // default indicates if the widget is automatically added for the user
+  default?: boolean
 }
 
 /*  BookmarkModelInput represents a bookmark as it is passed into MongoDB for updating  */

--- a/test/migrations/add-featured-shortcuts-widget.test.js
+++ b/test/migrations/add-featured-shortcuts-widget.test.js
@@ -1,0 +1,129 @@
+import { ObjectId } from 'mongodb'
+import { connectDb } from '../../utils/mongodb'
+import {
+  up,
+  down,
+} from '../../migrations/1679951734168-add-featured-shortcuts-widget'
+
+const NEWS_COLLECTION = {
+  _id: ObjectId(),
+  title: 'Recent news',
+  type: 'News',
+}
+const FEATURED_SHORTCUTS_USER_ADDED = {
+  _id: ObjectId(),
+  title: 'Featured Shortcuts',
+  type: 'FeaturedShortcuts',
+}
+
+describe('[Migration: Add Featured Shortcuts to MySpace]', () => {
+  const testUserId1 = 'testUserId1'
+  const testUserId2 = 'testUserId2'
+  let connection
+  let db
+
+  beforeAll(async () => {
+    // This is NOT the connection used in the migration itself
+    // Just use to seed data for the test
+    const mongoConnection = await connectDb()
+    connection = mongoConnection.connection
+    db = mongoConnection.db
+
+    // Reset db
+    await db.collection('users').deleteMany({})
+
+    // Create a test user with non-empty MySpace
+    // No FeaturedShortcuts widget
+    await db.collection('users').insertOne({
+      userId: testUserId1,
+      mySpace: [NEWS_COLLECTION],
+    })
+
+    // Create a test user with non-empty MySpace
+    // Existing FeaturedShortcuts widget
+    await db.collection('users').insertOne({
+      userId: testUserId2,
+      mySpace: [FEATURED_SHORTCUTS_USER_ADDED, NEWS_COLLECTION],
+    })
+  })
+
+  afterAll(async () => {
+    await connection.close()
+  })
+
+  it('up, no existing FeaturedShortcuts', async () => {
+    // User does not have FeaturedShortcuts widget before up migration
+    let user = await db.collection('users').findOne({ userId: testUserId1 })
+
+    user.mySpace.forEach((c) => {
+      expect(c.type).not.toEqual('FeaturedShortcuts')
+    })
+
+    await up()
+    // FeaturedShortcuts widget is added as first widget in MySpace
+    user = await db.collection('users').findOne({ userId: testUserId1 })
+    const firstWidget = user.mySpace[0]
+
+    expect(firstWidget).toHaveProperty('type')
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+    expect(firstWidget.default).toEqual(true)
+  })
+
+  it('down, remove FeaturedShorcuts added by migration', async () => {
+    // User has FeaturedShortcuts widget before down migration
+    let user = await db.collection('users').findOne({ userId: testUserId1 })
+    let firstWidget = user.mySpace[0]
+
+    expect(firstWidget).toHaveProperty('type')
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+    expect(firstWidget.default).toBe(true)
+
+    await down()
+    // Because FeaturedCollections was added by the migration,
+    // it will be removed from MySpace
+    user = await db.collection('users').findOne({ userId: testUserId1 })
+    firstWidget = user.mySpace[0]
+    expect(firstWidget.type).not.toEqual('FeaturedShortcuts')
+  })
+
+  it('up, user added FeaturedShortcuts', async () => {
+    // User has FeaturedShortcuts widget before up migration
+    let user = await db.collection('users').findOne({ userId: testUserId2 })
+    let firstWidget = user.mySpace[0]
+
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+    expect(firstWidget.default).toBeUndefined()
+
+    await up()
+
+    user = await db.collection('users').findOne({ userId: testUserId2 })
+    firstWidget = user.mySpace[0]
+
+    // Verify the first widget remains the same after up migration
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+    expect(firstWidget.default).toBeUndefined()
+
+    // Verify no other FeaturedShortcuts widgets have been added to MySpace
+    const featuredShortcuts = user.mySpace.filter(
+      (w) => w.type === 'FeaturedShortcuts'
+    )
+    expect(featuredShortcuts.length).toBe(1)
+  })
+
+  it('down, do not remove FeaturedShorcuts added by user', async () => {
+    // User has FeaturedShortcuts widget before down migration
+    let user = await db.collection('users').findOne({ userId: testUserId2 })
+    let firstWidget = user.mySpace[0]
+
+    expect(firstWidget).toHaveProperty('type')
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+    expect(firstWidget.default).toBeUndefined()
+
+    await down()
+    // Because FeaturedCollections was not added by the migration,
+    // it remains the same
+    user = await db.collection('users').findOne({ userId: testUserId2 })
+    firstWidget = user.mySpace[0]
+    expect(firstWidget.type).toEqual('FeaturedShortcuts')
+  })
+})


### PR DESCRIPTION
# SC-1717

## Proposed changes

* New migration to add FeaturedShortcuts widget to users' MySpace
* If the user already has the FeaturedShortcuts widget, no action will be taken
* Down migration will only remove FeaturedShortcuts widget added by the migration. Users who added it previously should not be affected.
* To differentiate between users who already have the Featured Shortcuts widget in their MySpace, and users who will receive the update, I added the field `default: true` to the widget.


## Reviewer notes

* Happo diffs seem to be known issue with YouTube thumbnails, but tagging design for review anyway

## Setup

You can test the migration locally in two ways:

### Scenario 1: Log in to the portal app and verify you can see the Featured Shortcuts widget
1. Start the services with `yarn services:up`.  View the mongodb users via `localhost:8888` and verify there is an existing user. If you've recently purged your local db, log in as any user _before_ pulling down the branch. We want to verify that the migration is working correctly, so we need a 'before' state to compare it to.
2. If your user does have the Featured Shortcuts widget, remove it either via UI or Mongo Express.
3. Pull the branch. Run the app, and log in as the same user. You should now see the Featured Shortcuts component in MySpace.

### Scenario 2: Use migrate up/down

1. Pull down the branch. Start services with `yarn services:up`. View the mongodb users via `localhost:8888` and verify data for existing users.
2. If you've already pulled down the branch and logged in (Scenario 1), you'll need to run `yarn migrate down` first, since the migration has already ran. After doing this, the Featured Shortcuts widget should be removed from users that received it from the migration.
3. Run `yarn migrate up`.  Check data in Mongo Express.
  * Any user that did not already have the Featured Shortcuts widget should now have it.
  * If a user already had it, nothing should change.
4. Run `yarn migrate down`.
  * Users with the new default Featured Shortcuts widget should no longer have it.
  * Users who added it manually should still have it.


## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria, or will meet them in subsequent PRs or stories
  - ... <!-- link follow-up PRs/stories here -->
- [ ] Created new stories in Storybook if applicable
  - [ ] Checked that all Storybook accessibility checks are passing
- [ ] Created/modified automated unit tests in Jest
  - [ ] Including jest-axe checks when UI changes
- [ ] Created/modified automated E2E tests in Cypress
  - [ ] Including cypress-axe checks when UI changes
  - [ ] Checked that the E2E test build is not failing
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)
- [ ] Requested a design review for user-facing changes
- For any new migrations/schema changes:
  - [ ] Followed guidelines for zero-downtime deploys

### As code reviewer(s), I have

- [ ] Pulled this branch locally and tested it
- [ ] Reviewed this code and left comments
- [ ] Checked that all code is adequately covered by tests
  - [ ] Checked that the E2E test build is not failing
- [ ] Made it clear which comments need to be addressed before this work is merged
- [ ] Considered marking this as accepted even if there are small changes needed
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a designer reviewer, I have

- [ ] Checked in the design translated visually
- [ ] Checked behavior
- [ ] Checked different states (empty, one, some, error)
- [ ] Checked for landmarks, page heading structure, and links
- [ ] Tried to break the intended flow
- Performed [a11y testing](https://github.com/trussworks/accessibility/blob/master/sample_a11y_testing_process.md):
  - [ ] Checked responsiveness in mobile, tablet, and desktop
  - [ ] Checked keyboard navigability
  - [ ] Tested with [VoiceOver](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) in Safari
  - [ ] Checked VO's [rotor menu](https://github.com/trussworks/accessibility/blob/master/README.md#how-to-use-the-rotor-menu) for landmarks, page heading structure and links
  - [ ] Used a browser a11y tool to check for issues (WAVE, axe, ANDI or Accessibility addon tab for Storybook)

### As a test user, I have

- Run through the [Test Script](hhttps://docs.google.com/spreadsheets/d/1eV8UK0aJZ0qrzjnXf5SJ_uRiV7bpsj3yrhRFEkjOvV4/edit?usp=sharing):
  - [ ] On commercial internet in IE11
  - [ ] On commercial internet in Firefox
  - [ ] On commercial internet in Chrome
  - [ ] On commercial internet in Safari
  - [ ] On NIPR in IE11
  - [ ] On NIPR in Firefox
  - [ ] On NIPR in Chrome
  - [ ] On NIPR in Safari
  - [ ] On a mobile device in Firefox
  - [ ] On a mobile device in Chrome
  - [ ] On a mobile device in Safari
- [ ] Added any anomalous behavior to this PR

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
