### PR TITLE
fix: design: adds background fill settings box 

### DIFF
--- a/src/styles/pages/settings.module.scss
+++ b/src/styles/pages/settings.module.scss
@@ -10,6 +10,7 @@
 
   .widgetContainer {
     border: 1px solid $light-gray;
+    background: var(--background-fill);
     border-radius: 8px;
     padding: units(3) units(3);
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
# SC-1807


## Proposed changes

Adds background fill css to the widget box container surrounding the box on the settings page

sets text fields in light mode to default to white to account for layouts like this, they were transparent before, and we dont want text fields to become illegible if they are on an unexpected background in the future.


## Setup

```
yarn dev
```

http://localhost:3000/settings

---

## Screenshots
![Screen Shot 2023-03-30 at 15 21 26](https://user-images.githubusercontent.com/59394696/228942740-dbc37ccc-77b3-4437-b18a-6e9ea2e76077.png)

![Screen Shot 2023-03-30 at 15 21 32](https://user-images.githubusercontent.com/59394696/228942797-79e8823b-357e-44f3-8d02-4cd57eed1e46.png)

