### PR TITLE
fix: Remove any null bookmarks and prevent future ones

### DIFF
--- a/migrations/1680214667334-remove-null-bookmarks.js
+++ b/migrations/1680214667334-remove-null-bookmarks.js
@@ -1,0 +1,23 @@
+'use strict'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { runMigration } = require('../utils/mongodb')
+
+module.exports.up = runMigration(async (db) => {
+  await db.collection('users').updateMany(
+    {},
+    {
+      $pull: {
+        'mySpace.$[collection].bookmarks': null,
+      },
+    },
+    {
+      arrayFilters: [{ 'collection.bookmarks': null }],
+    }
+  )
+})
+
+module.exports.down = (next) => {
+  // nothing to do, null bookmarks were removed and we don't need them put back
+  next()
+}

--- a/src/operations/portal/mutations/editCollection.graphql
+++ b/src/operations/portal/mutations/editCollection.graphql
@@ -1,7 +1,7 @@
 mutation editCollection(
   $_id: OID!
   $title: String!
-  $bookmarks: [BookmarkReorderInput]
+  $bookmarks: [BookmarkReorderInput!]
 ) {
   editCollection(_id: $_id, title: $title, bookmarks: $bookmarks) {
     _id

--- a/src/schema.tsx
+++ b/src/schema.tsx
@@ -28,7 +28,7 @@ export const typeDefs = gql`
     _id: OID!
     title: String!
     type: WidgetType!
-    bookmarks: [Bookmark]
+    bookmarks: [Bookmark!]
     cmsId: ID
   }
 
@@ -73,7 +73,7 @@ export const typeDefs = gql`
     editCollection(
       _id: OID!
       title: String
-      bookmarks: [BookmarkReorderInput]
+      bookmarks: [BookmarkReorderInput!]
     ): Collection
     removeCollection(_id: OID!): Collection
     addBookmark(
@@ -124,7 +124,7 @@ export const typeDefs = gql`
   input CollectionRecordInput {
     id: ID!
     title: String!
-    bookmarks: [BookmarkRecordInput]
+    bookmarks: [BookmarkRecordInput!]
     type: String
   }
 

--- a/test/migrations/remove-null-bookmarks.test.js
+++ b/test/migrations/remove-null-bookmarks.test.js
@@ -1,0 +1,142 @@
+import { ObjectId } from 'mongodb'
+
+import { connectDb } from '../../utils/mongodb'
+
+import { up, down } from '../../migrations/1680214667334-remove-null-bookmarks'
+
+const TESTUSER1 = 'user1'
+const TEST_ACCOUNT_WITH_NULL_BOOKMARKS = [
+  {
+    _id: ObjectId(),
+    userId: TESTUSER1,
+    mySpace: [
+      {
+        _id: ObjectId(),
+        cmsId: 'ckwz3u58s1835ql974leo1yll',
+        title: 'Empty Collection',
+        type: 'Collection',
+        bookmarks: [],
+      },
+      {
+        _id: ObjectId(),
+        cmsId: 'ckwz3u58s1835ql974leo1yll',
+        title: 'A Collection',
+        type: 'Collection',
+        bookmarks: [
+          {
+            _id: ObjectId(),
+            cmsId: 'cktd7c0d30190w597qoftevq1',
+            url: 'https://afpcsecure.us.af.mil/',
+            label: 'vMPF',
+          },
+        ],
+      },
+      {
+        _id: ObjectId(),
+        cmsId: 'ckwz3u58s1835ql974leo1yll',
+        title: 'Example Collection',
+        type: 'Collection',
+        bookmarks: [
+          {
+            _id: ObjectId(),
+            cmsId: 'cktd7c0d30190w597qoftevq1',
+            url: 'https://afpcsecure.us.af.mil/',
+            label: 'vMPF',
+          },
+          null,
+          {
+            _id: ObjectId(),
+            cmsId: 'cktd7ettn0457w597p7ja4uye',
+            url: 'https://leave.af.mil/profile',
+            label: 'LeaveWeb',
+          },
+          {
+            _id: ObjectId(),
+            cmsId: 'cktd7hjz30636w5977vu4la4c',
+            url: 'https://mypay.dfas.mil/#/',
+            label: 'MyPay',
+          },
+          null,
+          {
+            _id: ObjectId(),
+            cmsId: 'ckwz3tphw1763ql97pia1zkvc',
+            url: 'https://webmail.apps.mil/',
+            label: 'Webmail',
+          },
+          {
+            _id: ObjectId(),
+            cmsId: 'ckwz3u4461813ql970wkd254m',
+            url: 'https://www.e-publishing.af.mil/',
+            label: 'e-Publications',
+          },
+        ],
+      },
+    ],
+    displayName: 'USER ONE',
+    theme: 'light',
+  },
+]
+
+describe('[Migration: Remove Null Bookmarks]', () => {
+  let connection
+  let db
+
+  beforeAll(async () => {
+    // This is NOT the connection used in the migration itself
+    // Just use to seed data for the test
+    const mongoConnection = await connectDb()
+    connection = mongoConnection.connection
+    db = mongoConnection.db
+
+    // Reset db
+    await db.collection('users').deleteMany({})
+
+    // Create a test user (with one default collection)
+    await db.collection('users').insertMany(TEST_ACCOUNT_WITH_NULL_BOOKMARKS)
+  })
+
+  afterAll(async () => {
+    await connection.close()
+  })
+
+  test('up', async () => {
+    let user = await db.collection('users').findOne({ userId: TESTUSER1 })
+
+    // user data should have a null bookmark to remove
+    let foundNull = user.mySpace.reduce((found, c) => {
+      const nullBookmarks = c.bookmarks.filter((b) => b === null)
+      return nullBookmarks.length > 0
+    }, false)
+
+    expect(foundNull).toBe(true)
+    expect(user.mySpace.length).toBe(3)
+    expect(user.mySpace[0].bookmarks.length).toBe(0)
+    expect(user.mySpace[1].bookmarks.length).toBe(1)
+    expect(user.mySpace[2].bookmarks.length).toBe(7)
+
+    // remove the null bookmarks
+    await up()
+
+    user = await db.collection('users').findOne({ userId: TESTUSER1 })
+
+    // check that there are no nulls
+    foundNull = user.mySpace.reduce((found, c) => {
+      const nullBookmarks = c.bookmarks.filter((b) => b === null)
+      return nullBookmarks.length > 0
+    }, false)
+
+    expect(foundNull).toBe(false)
+    expect(user.mySpace.length).toBe(3)
+    expect(user.mySpace[0].bookmarks.length).toBe(0)
+    expect(user.mySpace[1].bookmarks.length).toBe(1)
+    expect(user.mySpace[2].bookmarks.length).toBe(5)
+  })
+
+  test('down', async () => {
+    const downMock = jest.fn()
+
+    await down(downMock)
+
+    expect(downMock).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
# SC-1814

## Proposed changes

Somehow a user has a collection with a bookmark of value `null`. This PR changes our graphql schema to require bookmark objects in the collections objects to prevent this from happening again. It also introduces a migration that removes any null bookmark records from all users.

## Reviewer notes

Collection schema was changed so try as many collection actions as you can. If you want to test the migration use mongo express to add null as a record in bookmark then run the migration

To clear db of nulls
```
yarn migrate up 1680214667334-remove-null-bookmarks.js
```

To reset migration - does nothing to the data
```sh
yarn migrate down 1680214667334-remove-null-bookmarks.js
```

## Setup

Standard startup 

```sh
yarn services:up
cd ../cms && yarn dev
cd ../client && yarn dev
```