### PR TITLE
build: download ca bundle without strict cert check and verify sha256 sum

### DIFF
--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -11,8 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
-      - run: |
-          sudo sh scripts/add-dod-cas.sh
+      - name: Add DoD Certifaction Bundle
+        run: |
+          echo ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }} > scripts/dod_ca_cert_bundle.sha256
+          sudo bash scripts/add-dod-cas.sh
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
       - name: Add DoD Certifaction Bundle
+        env:
+          CERT_BUNDLE_SHA256: ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }}
         run: |
-          echo ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }} > scripts/dod_ca_cert_bundle.sha256
+          echo "$CERT_BUNDLE_SHA256" > scripts/dod_ca_cert_bundle.sha256
           sudo bash scripts/add-dod-cas.sh
 
       - name: Docker meta
@@ -44,9 +46,9 @@ jobs:
           TEST_CERT: ${{ secrets.C1_TEST_SAML_CERT }}
           PROD_CERT: ${{ secrets.C1_PROD_SAML_CERT }}
         run: |
-          echo $DEV_CERT > dev-saml.pem
-          echo $TEST_CERT > test-saml.pem
-          echo $PROD_CERT > prod-saml.pem
+          echo "$DEV_CERT" > dev-saml.pem
+          echo "$TEST_CERT" > test-saml.pem
+          echo "$PROD_CERT" > prod-saml.pem
 
       - name: Build
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4

--- a/.github/workflows/build-push-c1-art.yml
+++ b/.github/workflows/build-push-c1-art.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3
 
-      - name: Add DoD Certifaction Bundle
+      - name: Add DoD Certificate Bundle
         env:
           CERT_BUNDLE_SHA256: ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }}
         run: |

--- a/.github/workflows/dev-aws-ecr.yml
+++ b/.github/workflows/dev-aws-ecr.yml
@@ -58,9 +58,15 @@ jobs:
           TEST_CERT: ${{ secrets.C1_TEST_SAML_CERT }}
           PROD_CERT: ${{ secrets.C1_PROD_SAML_CERT }}
         run: |
-          echo $DEV_CERT > dev-saml.pem
-          echo $TEST_CERT > test-saml.pem
-          echo $PROD_CERT > prod-saml.pem
+          echo "$DEV_CERT" > dev-saml.pem
+          echo "$TEST_CERT" > test-saml.pem
+          echo "$PROD_CERT" > prod-saml.pem
+
+      - name: Add DoD Certificate Bundle
+        env:
+          CERT_BUNDLE_SHA256: ${{ secrets.DOD_CA_CERT_BUNDLE_SHA256 }}
+        run: |
+          echo "$CERT_BUNDLE_SHA256" > scripts/dod_ca_cert_bundle.sha256
 
       - name: Build and push
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,14 +72,14 @@ WORKDIR /app
 COPY --from=builder /app/scripts/add-rds-cas.sh .
 COPY --from=builder /app/scripts/add-dod-cas.sh .
 COPY --from=builder /app/scripts/create-gcds-chain.sh .
-COPY --from=builder /app/scripts/certificates_pkcs7_v5_11_dod.sha256 .
+COPY --from=builder /app/scripts/dod_ca_cert_bundle.sha256 ./scripts/dod_ca_cert_bundle.sha256
 COPY --from=builder /app/dev-saml.pem /usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt
 COPY --from=builder /app/test-saml.pem /usr/local/share/ca-certificates/federation.test.cce.af.mil.crt
 COPY --from=builder /app/prod-saml.pem /usr/local/share/ca-certificates/federation.prod.cce.af.mil.crt
 
 RUN apt-get update \
   && apt-get dist-upgrade -y \
-  && apt-get -y --no-install-recommends install ca-certificates dos2unix libc6 openssl unzip wget zlib1g
+  && apt-get -y --no-install-recommends install ca-certificates libc6 openssl unzip wget zlib1g
 
 RUN chmod +x add-rds-cas.sh && bash add-rds-cas.sh
 RUN chmod +x add-dod-cas.sh && bash add-dod-cas.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,15 +72,18 @@ WORKDIR /app
 COPY --from=builder /app/scripts/add-rds-cas.sh .
 COPY --from=builder /app/scripts/add-dod-cas.sh .
 COPY --from=builder /app/scripts/create-gcds-chain.sh .
+COPY --from=builder /app/scripts/certificates_pkcs7_v5_11_dod.sha256 .
 COPY --from=builder /app/dev-saml.pem /usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt
 COPY --from=builder /app/test-saml.pem /usr/local/share/ca-certificates/federation.test.cce.af.mil.crt
 COPY --from=builder /app/prod-saml.pem /usr/local/share/ca-certificates/federation.prod.cce.af.mil.crt
 
 RUN apt-get update \
   && apt-get dist-upgrade -y \
-  && apt-get -y --no-install-recommends install openssl libc6 ca-certificates wget unzip zlib1g \
-  && chmod +x add-rds-cas.sh && sh add-rds-cas.sh \
-  && chmod +x add-dod-cas.sh && sh add-dod-cas.sh && chmod +x create-gcds-chain.sh && sh create-gcds-chain.sh
+  && apt-get -y --no-install-recommends install ca-certificates dos2unix libc6 openssl unzip wget zlib1g
+
+RUN chmod +x add-rds-cas.sh && bash add-rds-cas.sh
+RUN chmod +x add-dod-cas.sh && bash add-dod-cas.sh
+RUN chmod +x create-gcds-chain.sh && bash create-gcds-chain.sh
 
 ##--------- Stage: runner ---------##
 

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -14,8 +14,6 @@
     unzip unclass-certificates_pkcs7_DoD.zip
 
     # check that Checksums verify
-    # output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in ../certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
-    # echo 123 >> certificates_pkcs7_v5_11_dod/certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b
     output=$(cd certificates_pkcs7_v5_11_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
     echo $output
     if [[ "$output" == *"FAILED"* ]]; then

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -7,8 +7,16 @@
 
     # Extract the bundle
     cd /usr/local/share/ca-certificates
-    wget $bundle
+    wget --no-check-certificate $bundle
     unzip unclass-certificates_pkcs7_DoD.zip
+
+    # check that Checksums verify
+    output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in /app/certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
+    echo $output
+    if [[ "$output" == *"FAILED"* ]]; then
+        echo "Checksum failed" >&2
+        exit 1
+    fi
 
     # Convert the PKCS#7 bundle into individual PEM files
     openssl pkcs7 -print_certs -in certificates_pkcs7_v5_11_dod/*_pem.p7b |

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -15,7 +15,7 @@
 
     # check that Checksums verify
     # output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in ../certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
-    echo 123 >> certificates_pkcs7_v5_11_dod/certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b
+    # echo 123 >> certificates_pkcs7_v5_11_dod/certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b
     output=$(cd certificates_pkcs7_v5_11_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
     echo $output
     if [[ "$output" == *"FAILED"* ]]; then

--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -5,13 +5,18 @@
     # Location of bundle from DISA site
     bundle=https://dl.dod.cyber.mil/wp-content/uploads/pki-pke/zip/unclass-certificates_pkcs7_DoD.zip
 
+    # Copy the Checksum file
+    cp ./scripts/dod_ca_cert_bundle.sha256 /usr/local/share/ca-certificates/
+
     # Extract the bundle
     cd /usr/local/share/ca-certificates
     wget --no-check-certificate $bundle
     unzip unclass-certificates_pkcs7_DoD.zip
 
     # check that Checksums verify
-    output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in /app/certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
+    # output=$(cd certificates_pkcs7_v5_11_dod; openssl smime -verify -in ../certificates_pkcs7_v5_11_dod.sha256 -inform DER -CAfile dod_pke_chain.pem | dos2unix | sha256sum -c)
+    echo 123 >> certificates_pkcs7_v5_11_dod/certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b
+    output=$(cd certificates_pkcs7_v5_11_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
     echo $output
     if [[ "$output" == *"FAILED"* ]]; then
         echo "Checksum failed" >&2

--- a/scripts/create-gcds-chain.sh
+++ b/scripts/create-gcds-chain.sh
@@ -3,16 +3,16 @@
 cd /usr/local/share/ca-certificates
 
 # Make Dev GCDS PEM
-for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-49.crt" "/usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt"; do
+for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-59.crt" "/usr/local/share/ca-certificates/federation.dev.cce.af.mil.crt"; do
     (cat "${cert}") >> Dev-GCDS.pem;
 done
 
 # Make Test GCDS PEM
-for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-49.crt" "/usr/local/share/ca-certificates/federation.test.cce.af.mil.crt"; do
+for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-59.crt" "/usr/local/share/ca-certificates/federation.test.cce.af.mil.crt"; do
     (cat "${cert}") >> Test-GCDS.pem;
 done
 
 # Make Prod GCDS PEM
-for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-49.crt" "/usr/local/share/ca-certificates/federation.prod.cce.af.mil.crt"; do
+for cert in "/usr/local/share/ca-certificates/DoD_Root_CA_3.crt" "/usr/local/share/ca-certificates/DOD_EMAIL_CA-59.crt" "/usr/local/share/ca-certificates/federation.prod.cce.af.mil.crt"; do
     (cat "${cert}") >> Prod-GCDS.pem;
 done


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- added a checksum file for Certs in DoD PKI CA Cert bundle from GH Secrets
- modfiy `add-dod-cas.sh` to download Cert bundle without strict TLS verification
- modify `add-dod.cas.sh` to verify the sha256 checksum of the certs that are downloaded against the checksum file to deter MITM attacks
---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Code review steps

The workflow `.github/workflows/build-push-c1-art.yml` was tested with a manual dispatch and the results can be seen here: https://github.com/USSF-ORBIT/ussf-portal-client/actions/runs/4724289278

The output of the `Add DoD Certifaction Bundle` should include this:
```
 Verification successful
certificates_pkcs7_v5_11_dod_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_3_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_4_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_5_der.p7b: OK certificates_pkcs7_v5_11_dod_dod_root_ca_6_der.p7b: OK certificates_pkcs7_v5_11_dod_pem.p7b: OK dod_pke_chain.pem: OK README.txt: OK
```
Which indicates that the checksum has passed.