### PR TITLE
chore: carry over cms renovate changes to client

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,37 +9,55 @@
     "group:storybookMonorepo",
     "npm:unpublishSafe",
     "packages:eslint",
-    "packages:jsUnitTest"
+    "packages:jsUnitTest",
+    "group:nodeJs",
+    "group:linters"
   ],
+  "labels": ["dependencies"],
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "rebaseWhen": "behind-base-branch",
-      "matchUpdateTypes": ["patch", "minor", "pin", "digest"],
-      "automerge": true,
-      "lockFileMaintenance": { "enabled": true },
-      "labels": ["dependencies"]
+      "matchUpdateTypes": ["patch", "minor", "pin", "digest"]
     },
     {
-      "matchPackageNames": ["uswds"],
-      "enabled": false
-    },
-    {
-      "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
       "managers": ["npm"],
       "matchUpdateTypes": ["minor", "patch"]
     },
     {
-      "managers": ["dockerfile"],
-      "matchUpdateTypes": ["major"],
+      "description": "Group minor and patch updates for devDependencies into a single PR",
+      "groupName": "devDependencies",
+      "managers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["devDependencies"]
+    },
+    {
+      "description": "Group minor and patch updates for github-actions into a single PR",
+      "groupName": "github-actions",
+      "managers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "labels": ["github-actions"]
+    },
+    {
+      "description": "Group minor and patch updates for docker-compose files into a single PR",
+      "groupName": "docker-compose",
+      "managers": ["docker-compose"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["docker-compose"]
+    },
+    {
+      "matchPackageNames": ["uswds"],
       "enabled": false
     },
     {
-      "groupName": "github-actions",
-      "managers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "labels": ["dependencies", "github-actions"]
+      "managers": ["dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "ignorePresets": [":prHourlyLimit2"]


### PR DESCRIPTION

## Proposed changes

- CMS and ussf-portal already have these changes which will make Renovate Bot work in way that's easier for humans to interact with.
- Dependencies will be groups in ways that make logical sense so that more PRs are automatically passing checks without needing human intervention
- Lock File Maintenance is enabled so that downstream dependencies also are updated on a regular cadence.