### PR TITLE
feat: Add event tracking to 404/500 error pages

### DIFF
--- a/src/__tests__/pages/404.test.tsx
+++ b/src/__tests__/pages/404.test.tsx
@@ -33,11 +33,11 @@ describe('404 page', () => {
       renderWithAuth(<Custom404 />, { user: null })
     })
 
-    it('renders the loader while fetching the user', () => {
+    test('renders the loader while fetching the user', () => {
       expect(screen.getByText('Content is loading...')).toBeInTheDocument()
     })
 
-    it('redirects to the login page if not logged in', async () => {
+    test('redirects to the login page if not logged in', async () => {
       await waitFor(() => {
         expect(mockReplace).toHaveBeenCalledWith('/login')
       })
@@ -49,7 +49,7 @@ describe('404 page', () => {
       renderWithAuth(<Custom404 />)
     })
 
-    it('renders the custom 404 page,', () => {
+    test('renders the custom 404 page,', () => {
       expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('404')
       expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
         'Looks like you’re a little lost'
@@ -59,17 +59,17 @@ describe('404 page', () => {
       )
     })
 
-    it('renders a go home button', () => {
+    test('renders a go home button', () => {
       expect(
         screen.getByRole('link', { name: 'Take me home' })
       ).toHaveAttribute('href', '/')
     })
 
-    it('makes the call to get user', () => {
+    test('makes the call to get user', () => {
       expect(axios.get).toHaveBeenLastCalledWith('/api/auth/user')
     })
 
-    it('renders feedback links', async () => {
+    test('renders feedback links', async () => {
       const feedbackLink = screen.getByText('Contact Us')
       expect(feedbackLink).toBeVisible()
       expect(feedbackLink).toHaveAttribute('href')

--- a/src/__tests__/pages/404.test.tsx
+++ b/src/__tests__/pages/404.test.tsx
@@ -4,9 +4,8 @@
 import { screen, waitFor } from '@testing-library/react'
 import { useRouter } from 'next/router'
 import axios from 'axios'
-
 import { renderWithAuth } from '../../testHelpers'
-
+import * as analyticsHooks from 'stores/analyticsContext'
 import Custom404 from 'pages/404'
 
 const mockReplace = jest.fn()
@@ -80,6 +79,22 @@ describe('404 page', () => {
       expect(feedbackLink.getAttribute('href')).toContain(
         'USSF portal feedback -- 404 page error'
       )
+    })
+
+    test('calls trackEvent with the correct arguments', async () => {
+      const mockTrackEvents = jest.fn()
+      jest.spyOn(analyticsHooks, 'useAnalytics').mockImplementation(() => {
+        return { push: jest.fn(), trackEvent: mockTrackEvents }
+      })
+      renderWithAuth(<Custom404 />)
+      await waitFor(() => {
+        expect(mockTrackEvents).toHaveBeenCalledWith(
+          'Error page',
+          'Page missing',
+          '404',
+          window.location.pathname
+        )
+      })
     })
   })
 })

--- a/src/__tests__/pages/500.test.tsx
+++ b/src/__tests__/pages/500.test.tsx
@@ -1,10 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useRouter } from 'next/router'
-
+import * as analyticsHooks from 'stores/analyticsContext'
 import Custom500 from 'pages/500'
 
 const mockBack = jest.fn()
@@ -69,5 +69,21 @@ describe('500 page', () => {
     expect(reportBugLink.getAttribute('href')).toContain(
       'USSF portal feedback -- 500 page error'
     )
+  })
+
+  test('calls trackEvent with the correct arguments', async () => {
+    const mockTrackEvents = jest.fn()
+    jest.spyOn(analyticsHooks, 'useAnalytics').mockImplementation(() => {
+      return { push: jest.fn(), trackEvent: mockTrackEvents }
+    })
+    render(<Custom500 />)
+    await waitFor(() => {
+      expect(mockTrackEvents).toHaveBeenCalledWith(
+        'Error page',
+        'Internal error',
+        '500',
+        window.location.pathname
+      )
+    })
   })
 })

--- a/src/__tests__/pages/500.test.tsx
+++ b/src/__tests__/pages/500.test.tsx
@@ -29,7 +29,7 @@ describe('500 page', () => {
     render(<Custom500 />)
   })
 
-  it('renders the custom 500 page,', () => {
+  test('renders the custom 500 page,', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('500')
     expect(screen.getByTestId('gridContainer')).toHaveTextContent(
       'Houston, we have a problem'
@@ -39,7 +39,7 @@ describe('500 page', () => {
     )
   })
 
-  it('renders a back button', async () => {
+  test('renders a back button', async () => {
     const user = userEvent.setup()
 
     const backButton = screen.getByRole('button', {
@@ -51,7 +51,7 @@ describe('500 page', () => {
     expect(mockBack).toHaveBeenCalled()
   })
 
-  it('renders feedback links', async () => {
+  test('renders feedback links', async () => {
     const feedbackLink = screen.getByText('feedback@ussforbit.us')
     expect(feedbackLink).toBeVisible()
     expect(feedbackLink).toHaveAttribute('href')

--- a/src/__tests__/pages/_error.test.tsx
+++ b/src/__tests__/pages/_error.test.tsx
@@ -88,7 +88,7 @@ describe('custome error page', () => {
     expect(getInitialProps).toBeInstanceOf(Function)
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore ignore getInitialProps being possibly undefined because we just checked it
-    const result = await getInitialProps({ res: {} })
+    const result = await getInitialProps({})
     expect(result).toBeDefined()
     expect(result).toEqual({ statusCode: 404 })
   })

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,12 +6,16 @@ import Loader from 'components/Loader/Loader'
 import { withErrorLayout } from 'layout/ErrorLayout/ErrorLayout'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 import Logo from 'components/Logo/Logo'
+import { useAnalytics } from 'stores/analyticsContext'
 
 const FEEDBACK_EMAIL = 'feedback@ussforbit.us'
 const FEEDBACK_SUBJECT = 'USSF portal feedback -- 404 page error'
 
 export default function Custom404() {
   const { user } = useUser()
+  const { trackEvent } = useAnalytics()
+
+  trackEvent('Error page', 'Page missing', '404', window.location.pathname)
 
   return !user ? (
     <Loader />

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -3,14 +3,17 @@ import { useRouter } from 'next/router'
 
 import { withErrorLayout } from 'layout/ErrorLayout/ErrorLayout'
 import Logo from 'components/Logo/Logo'
+import { useAnalytics } from 'stores/analyticsContext'
 
 const FEEDBACK_EMAIL = 'feedback@ussforbit.us'
 const FEEDBACK_SUBJECT = 'USSF portal feedback -- 500 page error'
 
 export default function Custom500() {
   const router = useRouter()
-
+  const { trackEvent } = useAnalytics()
   const handleBackClick = () => router.back()
+
+  trackEvent('Error page', 'Internal error', '500', window.location.pathname)
 
   return (
     <>

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next'
 import type { ReactElement, ReactNode } from 'react'
 import { Button, GridContainer } from '@trussworks/react-uswds'
 import { useRouter } from 'next/router'
+import { useAnalytics } from 'stores/analyticsContext'
 
 import { withErrorLayout } from 'layout/ErrorLayout/ErrorLayout'
 import Logo from 'components/Logo/Logo'
@@ -17,9 +18,17 @@ type NextPageWithLayout<P> = NextPage<P> & {
 }
 
 const Error: NextPageWithLayout<Props> = ({ statusCode }: Props) => {
+  const { trackEvent } = useAnalytics()
   const router = useRouter()
   const handleBackClick = () => router.back()
   const errorCode = statusCode ? statusCode : 500
+
+  trackEvent(
+    'Error page',
+    'Internal error',
+    errorCode.toString(),
+    window.location.pathname
+  )
 
   const feedback_subject = `USSF portal feedback -- ${errorCode} page error`
 

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -23,6 +23,7 @@ const Error: NextPageWithLayout<Props> = ({ statusCode }: Props) => {
   const handleBackClick = () => router.back()
   const errorCode = statusCode ? statusCode : 500
 
+  // TODO: see if error message is also passed in so we can include that
   trackEvent(
     'Error page',
     'Internal error',


### PR DESCRIPTION
# SC-1866

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Add event tracking to 404 and 500 pages
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Check the console in your browser and you should see a `trackEvent` log when visiting either the `/404` or `/500` pages. You could also try looking at the local instance of Matomo at `https://localhost:8443` but I'm not sure how long it takes for user events to pop up there.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
