### PR TITLE
dev: error on detect-object-injection

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
   ],
   "rules": {
     "no-console": "warn",
+    "security/detect-object-injection": "error",
     "import/no-useless-path-segments": "warn",
     "import/no-cycle": "error",
     "import/no-extraneous-dependencies": "error",
@@ -61,7 +62,10 @@
     },
     "linkComponents": [
       // Components used as alternatives to <a> for linking, eg. <Link to={ url } />
-      { "name": "LinkTo", "attribute": "href" }
+      {
+        "name": "LinkTo",
+        "attribute": "href"
+      }
     ]
   },
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,7 @@
     "jest"
   ],
   "rules": {
-    "no-console": "warn",
+    "no-console": "off",
     "security/detect-object-injection": "error",
     "import/no-useless-path-segments": "warn",
     "import/no-cycle": "error",

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -23,9 +23,12 @@ export const Label = ({
   type,
   children,
 }: {
-  type: typeof LabelTypes[number]
+  type: (typeof LabelTypes)[number]
   children: React.ReactNode
 }) => (
+  // type variable can only be one of the constants defined on by LabelTypes
+  // also only changes the selected style
+  // eslint-disable-next-line security/detect-object-injection
   <USWDSTag className={`${styles.Label} ${styles[type]}`}>
     <Icon.Label aria-label="label" size={3} /> {children}
   </USWDSTag>
@@ -35,7 +38,7 @@ export const Label = ({
 export const Category = ({
   category,
 }: {
-  category: typeof CONTENT_CATEGORIES[keyof typeof CONTENT_CATEGORIES]
+  category: (typeof CONTENT_CATEGORIES)[keyof typeof CONTENT_CATEGORIES]
 }) => (
   <USWDSTag className={`${styles.Category} ${styles[category.value]}`}>
     {category.label}

--- a/startup/logging.js
+++ b/startup/logging.js
@@ -19,6 +19,9 @@ function setUpLogging() {
   // testCircular.d = testCircular
 
   function getLoggingFunction(/** @type {string} */ levelName) {
+    // levelName is passed in by this setup code when calling this function
+    // not user input
+    // eslint-disable-next-line security/detect-object-injection
     const baseLogFn = (logger[levelName] || logger.info).bind(logger)
     return function patchedLog(/** @type {any[]} */ ...parts) {
       /** @type {object | undefined} */
@@ -61,6 +64,8 @@ function setUpLogging() {
       continue
     }
 
+    // property is not a user provided value but code from nextjs
+    // eslint-disable-next-line security/detect-object-injection
     nextBuiltInLogger[property] = getLoggingFunction(property)
   }
 
@@ -70,6 +75,10 @@ function setUpLogging() {
    */
   const loggingProperties = ['log', 'debug', 'info', 'warn', 'error']
   for (const property of loggingProperties) {
+    // property is coming from loggingProperties which is a hard coded array
+    // also following line is an approved setup of console logging
+    // so ingoring the no-console check
+    // eslint-disable-next-line security/detect-object-injection,no-console
     console[property] = getLoggingFunction(property)
   }
 

--- a/startup/logging.js
+++ b/startup/logging.js
@@ -76,9 +76,7 @@ function setUpLogging() {
   const loggingProperties = ['log', 'debug', 'info', 'warn', 'error']
   for (const property of loggingProperties) {
     // property is coming from loggingProperties which is a hard coded array
-    // also following line is an approved setup of console logging
-    // so ingoring the no-console check
-    // eslint-disable-next-line security/detect-object-injection,no-console
+    // eslint-disable-next-line security/detect-object-injection
     console[property] = getLoggingFunction(property)
   }
 


### PR DESCRIPTION
## Proposed changes

This has been on my mind for a while. I made `security/detect-object-injection` as error level lint issues. This will break the build if you add any. This PR fixes a couple issues and marks the rest as accepted exceptions to that.  This PR also disabled `no-console` as a warning since we use `console` messages for server side logging. See https://eslint.org/docs/latest/rules/no-console

I am doing this because it is easy to ignore warnings and I wanted to help reduce that concern and allow us to document when we add exceptions to that. 

This is a proposal and not necessarily how we need to do things so feel free to push back on making the two lint checks error level vs warning level.

## Reviewer notes

Review the fixes and any comments disabling specific lines for accuracy and clarity.

NOTE: ADR proposed for this change USSF-ORBIT/ussf-portal#265

## Setup

### Lint should be clear of errors, and no warnings related to console or object injection

```sh
yarn lint
```
