### PR TITLE
build: add release-please to the project

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,3 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
-          labels:
-            - 'autorelease: pending'
-            - 'type: release'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: node
+          package-name: release-please-action
+          labels:
+            - 'autorelease: pending'
+            - 'type: release'


### PR DESCRIPTION
# SC-1232

## Proposed changes

Add a workflow to automate release PR creation with [release-please GH action](https://github.com/google-github-actions/release-please-action). I left standard-version in the `package.json` and the release instructions as I'd like to see how this works first.

## Reviewer notes

Probably nothing to do until this is merged and we use it for our next release.