### PR TITLE
refactor: Update Add Section labels

### DIFF
--- a/src/__tests__/pages/sites-and-applications.test.tsx
+++ b/src/__tests__/pages/sites-and-applications.test.tsx
@@ -565,7 +565,7 @@ describe('Sites and Applications page', () => {
           const flashMessage = screen.getAllByRole('alert')[0]
 
           expect(flashMessage).toHaveTextContent(
-            `You have successfully added “${mockCMSBookmarks[0].label}” to the “Example Collection” section.`
+            `You have successfully added “${mockCMSBookmarks[0].label}” to the “Example Collection” collection.`
           )
 
           await act(async () => {

--- a/src/components/AddWidget/AddWidget.stories.tsx
+++ b/src/components/AddWidget/AddWidget.stories.tsx
@@ -17,8 +17,8 @@ export default {
   argTypes: {
     handleSelectCollection: { action: 'Select collection from template' },
     handleCreateCollection: { action: 'Create new collection' },
-    handleAddNews: { action: 'Add news section' },
-    handleAddGuardianIdeal: { action: 'Add Guardian Ideal section' },
+    handleAddNews: { action: 'Add news widget' },
+    handleAddGuardianIdeal: { action: 'Add Guardian Ideal widget' },
     handleAddFeaturedShortcuts: { action: 'Add Featured Shortcuts' },
   },
   decorators: [
@@ -51,7 +51,7 @@ export const AddCollectionDisabled = (argTypes: StorybookArgTypes) => (
   />
 )
 
-export const NewsSectionDisabled = (argTypes: StorybookArgTypes) => (
+export const NewsWidgetDisabled = (argTypes: StorybookArgTypes) => (
   <AddWidget
     handleSelectCollection={argTypes.handleSelectCollection}
     handleCreateCollection={argTypes.handleCreateCollection}

--- a/src/components/AddWidget/AddWidget.test.tsx
+++ b/src/components/AddWidget/AddWidget.test.tsx
@@ -22,7 +22,7 @@ describe('AddWidget component', () => {
   it('renders an add widget menu', () => {
     render(<AddWidget {...testProps} />)
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
   })
 
@@ -39,7 +39,7 @@ describe('AddWidget component', () => {
       screen.queryByRole('button', { name: 'Select collection from template' })
     ).not.toBeInTheDocument()
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
     await user.click(menuButton)
 
@@ -61,7 +61,7 @@ describe('AddWidget component', () => {
       <AddWidget {...testProps} handleSelectCollection={mockHandleSelect} />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
@@ -89,7 +89,7 @@ describe('AddWidget component', () => {
       <AddWidget {...testProps} handleCreateCollection={mockHandleCreate} />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
@@ -121,7 +121,7 @@ describe('AddWidget component', () => {
       />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
@@ -146,29 +146,29 @@ describe('AddWidget component', () => {
     expect(mockHandleCreate).not.toHaveBeenCalled()
   })
 
-  it('handles the Add news section button', async () => {
+  it('handles the Add news widget button', async () => {
     const user = userEvent.setup()
     const mockAddNews = jest.fn()
 
     render(<AddWidget {...testProps} handleAddNews={mockAddNews} />)
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add news section' })
+      screen.getByRole('button', { name: 'Add news widget' })
     ).toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Add news section' }))
+    await user.click(screen.getByRole('button', { name: 'Add news widget' }))
 
     expect(mockAddNews).toHaveBeenCalled()
     expect(
-      screen.queryByRole('button', { name: 'Add news section' })
+      screen.queryByRole('button', { name: 'Add news widget' })
     ).not.toBeInTheDocument()
   })
 
-  it('the Add news section button is disabled if the user cannot add News', async () => {
+  it('the Add news widget button is disabled if the user cannot add News', async () => {
     const user = userEvent.setup()
     const mockAddNews = jest.fn()
 
@@ -180,23 +180,23 @@ describe('AddWidget component', () => {
       />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add news section' })
+      screen.getByRole('button', { name: 'Add news widget' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Add news section' })
+      screen.getByRole('button', { name: 'Add news widget' })
     ).toBeDisabled()
 
-    await user.click(screen.getByRole('button', { name: 'Add news section' }))
+    await user.click(screen.getByRole('button', { name: 'Add news widget' }))
     expect(mockAddNews).not.toHaveBeenCalled()
   })
 
-  test('handles Add Guardian Ideal section button', async () => {
+  test('handles Add Guardian Ideal widget button', async () => {
     const user = userEvent.setup()
     const mockAddGuardianIdeal = jest.fn()
 
@@ -208,25 +208,25 @@ describe('AddWidget component', () => {
       <AddWidget {...testProps} handleAddGuardianIdeal={mockAddGuardianIdeal} />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.getByRole('button', { name: 'Add Guardian Ideal widget' })
     ).toBeInTheDocument()
     await user.click(
-      screen.getByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.getByRole('button', { name: 'Add Guardian Ideal widget' })
     )
 
     expect(mockAddGuardianIdeal).toHaveBeenCalled()
     expect(
-      screen.queryByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.queryByRole('button', { name: 'Add Guardian Ideal widget' })
     ).not.toBeInTheDocument()
   })
 
-  test('the Add Guardian Ideal section button is disabled if the user cannot add it', async () => {
+  test('the Add Guardian Ideal widget button is disabled if the user cannot add it', async () => {
     const user = userEvent.setup()
     const mockAddGuardianIdeal = jest.fn()
 
@@ -238,25 +238,25 @@ describe('AddWidget component', () => {
       />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.getByRole('button', { name: 'Add Guardian Ideal widget' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.getByRole('button', { name: 'Add Guardian Ideal widget' })
     ).toBeDisabled()
 
     await user.click(
-      screen.getByRole('button', { name: 'Add Guardian Ideal section' })
+      screen.getByRole('button', { name: 'Add Guardian Ideal widget' })
     )
     expect(mockAddGuardianIdeal).not.toHaveBeenCalled()
   })
 
-  test('handles Add Featured Shortcuts section button', async () => {
+  test('handles Add Featured Shortcuts widget button', async () => {
     const user = userEvent.setup()
     const mockAddFeaturedShortcuts = jest.fn()
 
@@ -271,25 +271,25 @@ describe('AddWidget component', () => {
       />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.getByRole('button', { name: 'Add Featured Shortcuts widget' })
     ).toBeInTheDocument()
     await user.click(
-      screen.getByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.getByRole('button', { name: 'Add Featured Shortcuts widget' })
     )
 
     expect(mockAddFeaturedShortcuts).toHaveBeenCalled()
     expect(
-      screen.queryByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.queryByRole('button', { name: 'Add Featured Shortcuts widget' })
     ).not.toBeInTheDocument()
   })
 
-  test('the Add Featured Shortcuts section button is disabled if the user cannot add it', async () => {
+  test('the Add Featured Shortcuts widget button is disabled if the user cannot add it', async () => {
     const user = userEvent.setup()
     const mockAddFeaturedShortcuts = jest.fn()
     mockFlags({
@@ -304,20 +304,20 @@ describe('AddWidget component', () => {
       />
     )
 
-    const menuButton = screen.getByRole('button', { name: 'Add section' })
+    const menuButton = screen.getByRole('button', { name: 'Add widget' })
     expect(menuButton).toBeInTheDocument()
 
     await user.click(menuButton)
 
     expect(
-      screen.getByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.getByRole('button', { name: 'Add Featured Shortcuts widget' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.getByRole('button', { name: 'Add Featured Shortcuts widget' })
     ).toBeDisabled()
 
     await user.click(
-      screen.getByRole('button', { name: 'Add Featured Shortcuts section' })
+      screen.getByRole('button', { name: 'Add Featured Shortcuts widget' })
     )
     expect(mockAddFeaturedShortcuts).not.toHaveBeenCalled()
   })

--- a/src/components/AddWidget/AddWidget.tsx
+++ b/src/components/AddWidget/AddWidget.tsx
@@ -49,12 +49,12 @@ const AddWidget = ({
             type="button"
             id="addNewWidget"
             onClick={menuOnClick}
-            aria-label="Add section">
+            aria-label="Add widget">
             <span className={styles.plus}>
               <Icon.Add role="presentation" />
             </span>
             <br />
-            Add section{' '}
+            Add widget{' '}
             {isDropdownOpen ? (
               <Icon.ExpandLess aria-label="Open" />
             ) : (
@@ -89,7 +89,7 @@ const AddWidget = ({
             handleAddNews()
             setIsDropdownOpen(false)
           }}>
-          Add news section
+          Add news widget
         </Button>
         {flags?.guardianIdealCarousel && (
           <Button
@@ -99,7 +99,7 @@ const AddWidget = ({
               handleAddGuardianIdeal()
               setIsDropdownOpen(false)
             }}>
-            Add Guardian Ideal section
+            Add Guardian Ideal widget
           </Button>
         )}
         {flags?.featuredShortcuts && (
@@ -110,7 +110,7 @@ const AddWidget = ({
               handleAddFeaturedShortcuts()
               setIsDropdownOpen(false)
             }}>
-            Add Featured Shortcuts section
+            Add Featured Shortcuts widget
           </Button>
         )}
       </DropdownMenu>

--- a/src/components/CustomModal/CustomModal.stories.tsx
+++ b/src/components/CustomModal/CustomModal.stories.tsx
@@ -129,17 +129,17 @@ export const RemoveCustomCollectionModal = () => {
   )
 }
 
-export const RemoveSectionModal = () => {
+export const RemoveWidgetModal = () => {
   const { updateModalId, updateModalText, modalRef, updateWidget } =
     useModalContext()
 
   const openCustomLinkModal = () => {
-    updateModalId('removeNewsSectionModal')
+    updateModalId('removeNewsWidgetModal')
 
     updateModalText({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
 
     updateWidget({

--- a/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShorcuts.tsx
@@ -18,12 +18,12 @@ const FeaturedShortcuts = ({
     useModalContext()
   const { trackEvent } = useAnalytics()
 
-  const handleConfirmRemoveSection = () => {
-    updateModalId('removeFeaturedShortcutsSectionModal')
+  const handleConfirmRemoveWidget = () => {
+    updateModalId('removeFeaturedShortcutsWidgetModal')
     updateModalText({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
 
     const widgetState: Widget = {
@@ -54,8 +54,8 @@ const FeaturedShortcuts = ({
         <Button
           key="newsWidgetSettingsMenu_remove"
           type="button"
-          onClick={handleConfirmRemoveSection}>
-          Remove Featured Shortcuts section
+          onClick={handleConfirmRemoveWidget}>
+          Remove Featured Shortcuts widget
         </Button>,
       ]}>
       <ul className={styles.featuredShortcutsRow}>

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
@@ -31,7 +31,7 @@ describe('FeaturedShortcuts component', () => {
     expect(screen.getByRole('link', { name: 'LeaveWeb' })).toBeInTheDocument()
   })
 
-  test('can remove the Featured shortcuts Section', async () => {
+  test('can remove the Featured shortcuts widget', async () => {
     const user = userEvent.setup()
     const mockUpdateModalId = jest.fn()
     const mockUpdateModalText = jest.fn()
@@ -51,23 +51,23 @@ describe('FeaturedShortcuts component', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Section Settings',
+        name: 'Widget Settings',
       })
     )
 
     await user.click(
       await screen.findByRole('button', {
-        name: 'Remove Featured Shortcuts section',
+        name: 'Remove Featured Shortcuts widget',
       })
     )
 
     expect(mockUpdateModalId).toHaveBeenCalledWith(
-      'removeFeaturedShortcutsSectionModal'
+      'removeFeaturedShortcutsWidgetModal'
     )
     expect(mockUpdateModalText).toHaveBeenCalledWith({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
     expect(mockUpdateWidget).toHaveBeenCalled()
   })

--- a/src/components/GuardianIdeal/GuardianIdealCarousel.test.tsx
+++ b/src/components/GuardianIdeal/GuardianIdealCarousel.test.tsx
@@ -67,23 +67,23 @@ describe('GuardianIdealCarousel component', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Section Settings',
+        name: 'Widget Settings',
       })
     )
 
     await user.click(
       await screen.findByRole('button', {
-        name: 'Remove Guardian Ideal section',
+        name: 'Remove Guardian Ideal widget',
       })
     )
 
     expect(mockUpdateModalId).toHaveBeenCalledWith(
-      'removeGuardianIdealSectionModal'
+      'removeGuardianIdealWidgetModal'
     )
     expect(mockUpdateModalText).toHaveBeenCalledWith({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
     expect(mockUpdateWidget).toHaveBeenCalled()
   })

--- a/src/components/GuardianIdeal/GuardianIdealCarousel.tsx
+++ b/src/components/GuardianIdeal/GuardianIdealCarousel.tsx
@@ -98,12 +98,12 @@ const GuardianIdealCarousel = ({
     customPaging: () => <CustomEllipse />,
   }
 
-  const handleConfirmRemoveSection = () => {
-    updateModalId('removeGuardianIdealSectionModal')
+  const handleConfirmRemoveWidget = () => {
+    updateModalId('removeGuardianIdealWidgetModal')
     updateModalText({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
 
     const widgetState: Widget = {
@@ -125,8 +125,8 @@ const GuardianIdealCarousel = ({
           key="newsWidgetSettingsMenu_remove"
           type="button"
           className={styles.collectionSettingsDropdown}
-          onClick={handleConfirmRemoveSection}>
-          Remove Guardian Ideal section
+          onClick={handleConfirmRemoveWidget}>
+          Remove Guardian Ideal widget
         </Button>,
       ]}>
       <Slider

--- a/src/components/MySpace/MySpace.test.tsx
+++ b/src/components/MySpace/MySpace.test.tsx
@@ -93,23 +93,23 @@ describe('My Space Component', () => {
 
     test('renders the add widget component', async () => {
       expect(
-        await screen.findByRole('button', { name: 'Add section' })
+        await screen.findByRole('button', { name: 'Add widget' })
       ).toBeInTheDocument()
     })
 
-    test('disables adding a news section if there is already a news section', async () => {
+    test('disables adding a news widget if there is already a news widget', async () => {
       const user = userEvent.setup()
 
       expect(
-        await screen.findByRole('button', { name: 'Add section' })
+        await screen.findByRole('button', { name: 'Add widget' })
       ).toBeInTheDocument()
 
       await user.click(
-        await screen.findByRole('button', { name: 'Add section' })
+        await screen.findByRole('button', { name: 'Add widget' })
       )
       expect(
         screen.queryByRole('button', {
-          name: 'Add news section',
+          name: 'Add news widget',
         })
       ).toBeDisabled()
       expect(
@@ -141,13 +141,13 @@ describe('My Space Component', () => {
     })
 
     expect(
-      await screen.findByRole('button', { name: 'Add section' })
+      await screen.findByRole('button', { name: 'Add widget' })
     ).toBeInTheDocument()
 
-    await user.click(await screen.findByRole('button', { name: 'Add section' }))
+    await user.click(await screen.findByRole('button', { name: 'Add widget' }))
     expect(
       screen.queryByRole('button', {
-        name: 'Add news section',
+        name: 'Add news widget',
       })
     ).toBeEnabled()
     expect(
@@ -184,7 +184,7 @@ describe('My Space Component', () => {
     })
 
     expect(
-      screen.queryByRole('button', { name: 'Add section' })
+      screen.queryByRole('button', { name: 'Add widget' })
     ).not.toBeInTheDocument()
   })
 
@@ -195,7 +195,7 @@ describe('My Space Component', () => {
       portalUser: portalUserWithExampleCollection,
     })
 
-    await user.click(await screen.findByRole('button', { name: 'Add section' }))
+    await user.click(await screen.findByRole('button', { name: 'Add widget' }))
     await user.click(
       await screen.findByRole('button', {
         name: 'Select collection from template',
@@ -470,7 +470,7 @@ describe('My Space Component', () => {
       addCollectionMock
     )
 
-    await user.click(await screen.findByRole('button', { name: 'Add section' }))
+    await user.click(await screen.findByRole('button', { name: 'Add widget' }))
     await user.click(
       screen.getByRole('button', { name: 'Create new collection' })
     )

--- a/src/components/NewsWidget/NewsWidget.stories.tsx
+++ b/src/components/NewsWidget/NewsWidget.stories.tsx
@@ -17,7 +17,7 @@ export default {
   title: 'Components/NewsWidget',
   component: NewsWidget,
   argTypes: {
-    onRemove: { action: 'Remove this section' },
+    onRemove: { action: 'Remove this widget' },
   },
   decorators: [
     (Story) => (

--- a/src/components/NewsWidget/NewsWidget.test.tsx
+++ b/src/components/NewsWidget/NewsWidget.test.tsx
@@ -32,7 +32,7 @@ describe('NewsWidget component', () => {
     mockedAxios.get.mockClear()
   })
 
-  it('renders a widget that displays RSS items and a link to the News page', async () => {
+  test('renders a widget that displays RSS items and a link to the News page', async () => {
     render(<NewsWidget widget={mockNewsWidget} />)
 
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
@@ -46,24 +46,24 @@ describe('NewsWidget component', () => {
     )
   })
 
-  it('renders a settings menu', async () => {
+  test('renders a settings menu', async () => {
     const user = userEvent.setup()
     render(<NewsWidget widget={mockNewsWidget} />)
 
     user.click(
       screen.getByRole('button', {
-        name: 'Section Settings',
+        name: 'Widget Settings',
       })
     )
 
     const removeButton = await screen.findByRole('button', {
-      name: 'Remove this section',
+      name: 'Remove this widget',
     })
 
     expect(removeButton).toBeInTheDocument()
   })
 
-  it('clicking in settings to remove section passes correct values to modalContext', async () => {
+  test('clicking in settings to remove widget passes correct values to modalContext', async () => {
     const user = userEvent.setup()
     const mockUpdateModalId = jest.fn()
     const mockUpdateModalText = jest.fn()
@@ -77,21 +77,21 @@ describe('NewsWidget component', () => {
 
     await user.click(
       screen.getByRole('button', {
-        name: 'Section Settings',
+        name: 'Widget Settings',
       })
     )
 
     await user.click(
       await screen.findByRole('button', {
-        name: 'Remove this section',
+        name: 'Remove this widget',
       })
     )
 
-    expect(mockUpdateModalId).toHaveBeenCalledWith('removeNewsSectionModal')
+    expect(mockUpdateModalId).toHaveBeenCalledWith('removeNewsWidgetModal')
     expect(mockUpdateModalText).toHaveBeenCalledWith({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
     expect(mockUpdateWidget).toHaveBeenCalled()
   })

--- a/src/components/NewsWidget/NewsWidget.tsx
+++ b/src/components/NewsWidget/NewsWidget.tsx
@@ -29,14 +29,14 @@ const NewsWidget = (widget: NewsWidgetProps) => {
     fetchItems()
   }, [])
 
-  /** Remove section */
+  /** Remove widget */
   // Show confirmation modal
-  const handleConfirmRemoveSection = () => {
-    updateModalId('removeNewsSectionModal')
+  const handleConfirmRemoveWidget = () => {
+    updateModalId('removeNewsWidgetModal')
     updateModalText({
-      headingText: 'Are you sure you’d like to delete this section?',
+      headingText: 'Are you sure you’d like to delete this widget?',
       descriptionText:
-        'You can re-add it to your My Space from the Add Section menu.',
+        'You can re-add it to your My Space from the Add Widget menu.',
     })
 
     const widgetState: Widget = {
@@ -60,8 +60,8 @@ const NewsWidget = (widget: NewsWidgetProps) => {
             key="newsWidgetSettingsMenu_remove"
             type="button"
             className={styles.collectionSettingsDropdown}
-            onClick={handleConfirmRemoveSection}>
-            Remove this section
+            onClick={handleConfirmRemoveWidget}>
+            Remove this widget
           </Button>,
         ]}>
         {items

--- a/src/components/Widget/Widget.stories.tsx
+++ b/src/components/Widget/Widget.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from '@trussworks/react-uswds'
 import Widget, { WidgetWithSettings } from './Widget'
 
 export default {
-  title: 'Base/Section',
+  title: 'Base/Widget',
   component: Widget,
   decorators: [
     (Story) => (
@@ -16,15 +16,15 @@ export default {
   ],
 } as Meta
 
-export const ExampleSection = () => (
-  <Widget header={<h3>Example Section</h3>}>
-    <p>Example section contents</p>
+export const ExampleWidget = () => (
+  <Widget header={<h3>Example Widget</h3>}>
+    <p>Example widget contents</p>
   </Widget>
 )
 
-export const ExampleSectionWithSettings = () => (
+export const ExampleWidgetWithSettings = () => (
   <WidgetWithSettings
-    header={<h3>Example Section</h3>}
+    header={<h3>Example Widget</h3>}
     settingsItems={[
       <Button
         key="settingsMenu_item1"
@@ -32,9 +32,9 @@ export const ExampleSectionWithSettings = () => (
         onClick={() => {
           return
         }}>
-        Delete this section
+        Delete this widget
       </Button>,
     ]}>
-    <p>Example section contents</p>
+    <p>Example widget contents</p>
   </WidgetWithSettings>
 )

--- a/src/components/Widget/Widget.test.tsx
+++ b/src/components/Widget/Widget.test.tsx
@@ -13,28 +13,24 @@ import Widget, { WidgetWithSettings } from './Widget'
 describe('Widget component', () => {
   it('renders Widget', () => {
     render(
-      <Widget header={<h3>Example section</h3>}>
-        Example section contents
-      </Widget>
+      <Widget header={<h3>Example widget</h3>}>Example widget contents</Widget>
     )
 
     const heading = screen.getByRole('heading', { level: 3 })
 
-    expect(heading).toHaveTextContent('Example section')
-    expect(screen.getByText('Example section contents')).toBeInTheDocument()
+    expect(heading).toHaveTextContent('Example widget')
+    expect(screen.getByText('Example widget contents')).toBeInTheDocument()
   })
 
-  it('renders Widget without heading', () => {
-    render(<Widget>Example section contents</Widget>)
+  test('renders Widget without heading', () => {
+    render(<Widget>Example widget contents</Widget>)
 
-    expect(screen.getByText('Example section contents')).toBeInTheDocument()
+    expect(screen.getByText('Example widget contents')).toBeInTheDocument()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     const html = render(
-      <Widget header={<h3>Example section</h3>}>
-        Example section contents
-      </Widget>
+      <Widget header={<h3>Example widget</h3>}>Example widget contents</Widget>
     )
     expect(await axe(html.container)).toHaveNoViolations()
   })
@@ -48,41 +44,41 @@ describe('WidgetWithSettings component', () => {
   beforeEach(() => {
     html = render(
       <WidgetWithSettings
-        header={<h3>Example section</h3>}
-        settingsMenuLabel="Section Settings menu"
+        header={<h3>Example widget</h3>}
+        settingsMenuLabel="Widget Settings menu"
         settingsItems={[
           <button
             key="settingsMenu_item1"
             type="button"
             onClick={handleSettingsItemClick}>
-            Section settings handler
+            Widget settings handler
           </button>,
         ]}>
-        Example section contents
+        Example widget contents
       </WidgetWithSettings>
     )
   })
 
-  it('renders a heading', () => {
+  test('renders a heading', () => {
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
-      'Example section'
+      'Example widget'
     )
   })
 
-  it('render its children', () => {
-    expect(screen.getByText('Example section contents')).toBeInTheDocument()
+  test('render its children', () => {
+    expect(screen.getByText('Example widget contents')).toBeInTheDocument()
   })
 
-  it('renders the settings dropdown menu', async () => {
+  test('renders the settings dropdown menu', async () => {
     const user = userEvent.setup()
     const menuToggleButton = screen.getByRole('button', {
-      name: 'Section Settings menu',
+      name: 'Widget Settings menu',
     })
     expect(menuToggleButton).toBeInTheDocument()
 
     await user.click(menuToggleButton)
     const settingsItem = screen.getByRole('button', {
-      name: 'Section settings handler',
+      name: 'Widget settings handler',
     })
     expect(settingsItem).toBeInTheDocument()
 
@@ -92,16 +88,16 @@ describe('WidgetWithSettings component', () => {
     expect(handleSettingsItemClick).toHaveBeenCalled()
   })
 
-  it('clicking outside the dropdown menu closes the menu', async () => {
+  test('clicking outside the dropdown menu closes the menu', async () => {
     const user = userEvent.setup()
     const menuToggleButton = screen.getByRole('button', {
-      name: 'Section Settings menu',
+      name: 'Widget Settings menu',
     })
     expect(menuToggleButton).toBeInTheDocument()
 
     await user.click(menuToggleButton)
     const settingsItem = screen.getByRole('button', {
-      name: 'Section settings handler',
+      name: 'Widget settings handler',
     })
     expect(settingsItem).toBeInTheDocument()
 
@@ -111,15 +107,15 @@ describe('WidgetWithSettings component', () => {
     // Confirm the menu has been closed
     expect(
       screen.queryByRole('button', {
-        name: 'Section settings handler',
+        name: 'Widget settings handler',
       })
     ).not.toBeInTheDocument()
   })
 
-  it('clicking the menu button toggles the menu', async () => {
+  test('clicking the menu button toggles the menu', async () => {
     const user = userEvent.setup()
     const menuToggleButton = screen.getByRole('button', {
-      name: 'Section Settings menu',
+      name: 'Widget Settings menu',
     })
 
     // Open the menu
@@ -127,7 +123,7 @@ describe('WidgetWithSettings component', () => {
 
     expect(
       screen.getByRole('button', {
-        name: 'Section settings handler',
+        name: 'Widget settings handler',
       })
     ).toBeInTheDocument()
 
@@ -137,12 +133,12 @@ describe('WidgetWithSettings component', () => {
     // Confirm the menu has been closed
     expect(
       screen.queryByRole('button', {
-        name: 'Section settings handler',
+        name: 'Widget settings handler',
       })
     ).not.toBeInTheDocument()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     expect(await axe(html.container)).toHaveNoViolations()
   })
 })

--- a/src/components/Widget/Widget.tsx
+++ b/src/components/Widget/Widget.tsx
@@ -27,7 +27,7 @@ export default Widget
 export const WidgetWithSettings = ({
   header,
   settingsItems,
-  settingsMenuLabel = 'Section Settings',
+  settingsMenuLabel = 'Widget Settings',
   ...props
 }: {
   settingsItems: ReactNode[]

--- a/src/models/MySpace.test.ts
+++ b/src/models/MySpace.test.ts
@@ -37,19 +37,19 @@ describe('My Space model', () => {
     await connection.close()
   })
 
-  it('can get all widgets in a user’s My Space', async () => {
+  test('can get all widgets in a user’s My Space', async () => {
     const all = await MySpaceModel.get({ userId: testUserId }, { db })
     // Data: FeaturedShortcuts, GuardianIdeal, Example Collection
     expect(all).toHaveLength(3)
   })
 
-  it('throws an error if user is not found', async () => {
+  test('throws an error if user is not found', async () => {
     await expect(
       MySpaceModel.get({ userId: 'not a user' }, { db })
     ).rejects.toThrow()
   })
 
-  it('can add a News widget', async () => {
+  test('can add a News widget', async () => {
     const created = (await MySpaceModel.addWidget(
       { userId: testUserId, title: 'Recent news', type: 'News' },
       { db }
@@ -65,11 +65,11 @@ describe('My Space model', () => {
     expect(all).toHaveLength(4)
   })
 
-  it('can remove default Guardian Ideal widget', async () => {
+  test('can remove default Guardian Ideal widget', async () => {
     // Beginning Data: FeaturedShortcuts, GuardianIdeal, Example Collection, News
-    let allSections = await MySpaceModel.get({ userId: testUserId }, { db })
+    let allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
 
-    let guardianIdealWidget = allSections.find(
+    let guardianIdealWidget = allWidgets.find(
       (s) => s.type === WIDGETS.GUARDIANIDEAL.type
     )
 
@@ -81,8 +81,8 @@ describe('My Space model', () => {
         { db }
       )
 
-      allSections = await MySpaceModel.get({ userId: testUserId }, { db })
-      guardianIdealWidget = allSections.find(
+      allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
+      guardianIdealWidget = allWidgets.find(
         (s) => s.type === WIDGET_TYPES.GUARDIANIDEAL
       )
       expect(guardianIdealWidget).toBe(undefined)
@@ -90,7 +90,7 @@ describe('My Space model', () => {
     }
   })
 
-  it('can add a Guardian Ideal widget', async () => {
+  test('can add a Guardian Ideal widget', async () => {
     // Beginning Data: FeaturedShortcuts, Example Collection, News
     const created = (await MySpaceModel.addWidget(
       {
@@ -110,11 +110,11 @@ describe('My Space model', () => {
     expect(all).toHaveLength(4)
   })
 
-  it('can remove default Featured Shortcuts widget', async () => {
+  test('can remove default Featured Shortcuts widget', async () => {
     // Beginning Data: FeaturedShortcuts, GuardianIdeal, Example Collection, News
-    let allSections = await MySpaceModel.get({ userId: testUserId }, { db })
+    let allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
 
-    let featuredShortcutsWidget = allSections.find(
+    let featuredShortcutsWidget = allWidgets.find(
       (s) => s.type === WIDGETS.FEATUREDSHORTCUTS.type
     )
 
@@ -126,8 +126,8 @@ describe('My Space model', () => {
         { db }
       )
 
-      allSections = await MySpaceModel.get({ userId: testUserId }, { db })
-      featuredShortcutsWidget = allSections.find(
+      allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
+      featuredShortcutsWidget = allWidgets.find(
         (s) => s.type === WIDGET_TYPES.FEATUREDSHORTCUTS
       )
       expect(featuredShortcutsWidget).toBe(undefined)
@@ -135,7 +135,7 @@ describe('My Space model', () => {
     }
   })
 
-  it('can add a Featured Shortcut widget', async () => {
+  test('can add a Featured Shortcut widget', async () => {
     // Beginning Data: GuardianIdeal, Example Collection, News
     const created = (await MySpaceModel.addWidget(
       {
@@ -155,16 +155,16 @@ describe('My Space model', () => {
     expect(all).toHaveLength(4)
   })
 
-  it('cannot add a News widget if there already is one', async () => {
+  test('cannot add a News widget if there already is one', async () => {
     expect(
       MySpaceModel.addWidget(
         { userId: testUserId, title: 'Recent news', type: 'News' },
         { db }
       )
-    ).rejects.toThrow(new Error('You can only have one News section'))
+    ).rejects.toThrow(new Error('You can only have one News widget'))
   })
 
-  it('cannot add a Guardian Ideal widget if there already is one', async () => {
+  test('cannot add a Guardian Ideal widget if there already is one', async () => {
     expect(
       MySpaceModel.addWidget(
         {
@@ -174,10 +174,10 @@ describe('My Space model', () => {
         },
         { db }
       )
-    ).rejects.toThrow(new Error('You can only have one Guardian Ideal section'))
+    ).rejects.toThrow(new Error('You can only have one Guardian Ideal widget'))
   })
 
-  it('cannot add a Featured Shortcut widget if there already is one', async () => {
+  test('cannot add a Featured Shortcut widget if there already is one', async () => {
     expect(
       MySpaceModel.addWidget(
         {
@@ -188,11 +188,11 @@ describe('My Space model', () => {
         { db }
       )
     ).rejects.toThrow(
-      new Error('You can only have one Featured Shortcuts section')
+      new Error('You can only have one Featured Shortcuts widget')
     )
   })
 
-  it('throws an error if widget cannot be added', async () => {
+  test('throws an error if widget cannot be added', async () => {
     await expect(
       MySpaceModel.addWidget(
         { userId: 'wrong user id', title: 'Recent news', type: 'News' },
@@ -200,11 +200,11 @@ describe('My Space model', () => {
       )
     ).rejects.toThrow()
   })
-  it('can remove a News widget', async () => {
+  test('can remove a News widget', async () => {
     // Beginning Data: FeaturedShortcuts, GuardianIdeal, Example Collection, News
-    let allSections = await MySpaceModel.get({ userId: testUserId }, { db })
+    let allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
 
-    let newsWidget = allSections.find((s) => s.type === 'News')
+    let newsWidget = allWidgets.find((s) => s.type === 'News')
 
     expect(newsWidget).toBeTruthy()
 
@@ -214,14 +214,14 @@ describe('My Space model', () => {
         { db }
       )
 
-      allSections = await MySpaceModel.get({ userId: testUserId }, { db })
-      newsWidget = allSections.find((s) => s.type === 'News')
+      allWidgets = await MySpaceModel.get({ userId: testUserId }, { db })
+      newsWidget = allWidgets.find((s) => s.type === 'News')
       // Beginning Data: FeaturedShortcuts, GuardianIdeal, Example Collection
       expect(newsWidget).toBe(undefined)
     }
   })
 
-  it('throws an error if cannot find user or widget to remove', async () => {
+  test('throws an error if cannot find user or widget to remove', async () => {
     await expect(
       MySpaceModel.deleteWidget({ _id: ObjectId(), userId: 'cat' }, { db })
     ).rejects.toThrow()

--- a/src/models/MySpace.ts
+++ b/src/models/MySpace.ts
@@ -50,15 +50,15 @@ export const MySpaceModel = {
     if (type === 'News') {
       const allWidgets = await this.get({ userId }, { db })
       const newsWidget = allWidgets.find((s: Widget) => s.type === 'News')
-      if (newsWidget) throw new Error('You can only have one News section')
+      if (newsWidget) throw new Error('You can only have one News widget')
     }
 
     if (guardianIdealWidget && type === 'GuardianIdeal') {
-      throw new Error('You can only have one Guardian Ideal section')
+      throw new Error('You can only have one Guardian Ideal widget')
     }
 
     if (featuredShortcutsWidget && type === 'FeaturedShortcuts') {
-      throw new Error('You can only have one Featured Shortcuts section')
+      throw new Error('You can only have one Featured Shortcuts widget')
     }
 
     const created: Widget = {

--- a/src/pages/sites-and-applications.tsx
+++ b/src/pages/sites-and-applications.tsx
@@ -83,10 +83,10 @@ const SitesAndApplications = ({
     []
   const collectionsLength = userCollections.length || 0
 
-  const remainingSections =
+  const remainingCollections =
     MAXIMUM_COLLECTIONS - (collectionsLength + selectedCollections.length)
 
-  const canAddSections = collectionsLength < MAXIMUM_COLLECTIONS
+  const canAddCollections = collectionsLength < MAXIMUM_COLLECTIONS
 
   const handleSortClick = (sortType: SortBy) => {
     const sortTypeAction =
@@ -158,7 +158,7 @@ const SitesAndApplications = ({
       setFlash(
         <Alert type="success" slim role="alert" headingLevel="h4">
           You have successfully added “{bookmark.label}” to the “
-          {collection?.title}” section.
+          {collection?.title}” collection.
         </Alert>
       )
     } else {
@@ -223,7 +223,7 @@ const SitesAndApplications = ({
             </Alert>
           )}
 
-          {!canAddSections && (
+          {!canAddCollections && (
             <Alert type="warning" role="alert" headingLevel="h4">
               You have reached the maximum number of collections allowed on your
               My Space (25).
@@ -235,7 +235,7 @@ const SitesAndApplications = ({
             bookmarks={bookmarks}
             userCollectionOptions={userCollections}
             handleAddToCollection={handleAddToCollection}
-            canAddNewCollection={canAddSections}
+            canAddNewCollection={canAddCollections}
           />
         </div>
       )}
@@ -245,11 +245,11 @@ const SitesAndApplications = ({
           <div className={styles.widgetToolbar}>
             {selectMode ? (
               <>
-                {remainingSections < 3 && (
+                {remainingCollections < 3 && (
                   <Tooltip
                     position="top"
                     label={
-                      remainingSections > 0
+                      remainingCollections > 0
                         ? `You’re approaching the maximum number of collections (25) you can add to your My Space page.`
                         : `You can only add up to 25 collections to your My Space page.\nTo add a new collection, please remove an existing one.`
                     }>
@@ -261,7 +261,7 @@ const SitesAndApplications = ({
                     {selectedCollections.length} collection
                     {selectedCollections.length !== 1 && 's'} selected
                   </strong>{' '}
-                  ({remainingSections} of {MAXIMUM_COLLECTIONS} possible
+                  ({remainingCollections} of {MAXIMUM_COLLECTIONS} possible
                   remaining)
                 </span>
                 <Button
@@ -284,7 +284,7 @@ const SitesAndApplications = ({
               </>
             ) : (
               <>
-                {!canAddSections && (
+                {!canAddCollections && (
                   <Tooltip
                     position="top"
                     label={`You can only add up to 25 collections to your My Space page.\nTo add a new collection, please remove an existing one.`}>
@@ -301,7 +301,7 @@ const SitesAndApplications = ({
                     )
                     handleToggleSelectMode()
                   }}
-                  disabled={!canAddSections}>
+                  disabled={!canAddCollections}>
                   Select multiple collections
                 </Button>
               </>
@@ -324,7 +324,7 @@ const SitesAndApplications = ({
                       isSelected={isSelected(collection.id)}
                       onSelect={() => handleSelectCollection(collection.id)}
                       disabled={
-                        !isSelected(collection.id) && remainingSections < 1
+                        !isSelected(collection.id) && remainingCollections < 1
                       }
                     />
                   ) : (

--- a/src/stores/modalContext.test.tsx
+++ b/src/stores/modalContext.test.tsx
@@ -34,7 +34,7 @@ import {
 describe('Modal context', () => {
   afterEach(cleanup)
 
-  it('tests removing News widget', async () => {
+  test('tests removing News widget', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -98,7 +98,7 @@ describe('Modal context', () => {
     })
   })
 
-  it('tests adding a bookmark', async () => {
+  test('tests adding a bookmark', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -168,7 +168,7 @@ describe('Modal context', () => {
     expect(addBookmarkMock[0].result.data.label).toEqual('My Custom Label')
   })
 
-  it('tests editing a bookmark', async () => {
+  test('tests editing a bookmark', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -237,7 +237,7 @@ describe('Modal context', () => {
     expect(editBookmarkMock[0].result.data.label).toEqual('Updated Label')
   })
 
-  it('tests removing a bookmark while editing', async () => {
+  test('tests removing a bookmark while editing', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -304,7 +304,7 @@ describe('Modal context', () => {
     )
   })
 
-  it('tests removing a custom collection', async () => {
+  test('tests removing a custom collection', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -361,7 +361,7 @@ describe('Modal context', () => {
 })
 
 describe('useModalContext', () => {
-  it('returns the created context', () => {
+  test('returns the created context', () => {
     const { result } = renderHook(() => useModalContext())
     expect(result.current).toBeTruthy()
   })

--- a/src/stores/modalContext.test.tsx
+++ b/src/stores/modalContext.test.tsx
@@ -34,7 +34,7 @@ import {
 describe('Modal context', () => {
   afterEach(cleanup)
 
-  it('tests removing News section', async () => {
+  it('tests removing News widget', async () => {
     const user = userEvent.setup()
 
     const TestComponent = () => {
@@ -42,11 +42,11 @@ describe('Modal context', () => {
         useModalContext()
 
       const setupFunc = () => {
-        updateModalId('removeSectionModal')
+        updateModalId('removeWidgetModal')
         updateModalText({
-          headingText: 'Are you sure you’d like to delete this section?',
+          headingText: 'Are you sure you’d like to delete this widget?',
           descriptionText:
-            'You can re-add it to your My Space from the Add Section menu.',
+            'You can re-add it to your My Space from the Add Widget menu.',
         })
 
         const widgetState: Widget = {
@@ -64,7 +64,7 @@ describe('Modal context', () => {
         <div>
           <div id="modal-root" className="sfds" />
           <button type="button" onClick={setupFunc}>
-            Remove section
+            Remove widget
           </button>
           <CustomModal />
         </div>
@@ -80,14 +80,14 @@ describe('Modal context', () => {
     )
 
     const openModalButton = screen.getByRole('button', {
-      name: 'Remove section',
+      name: 'Remove widget',
     })
     expect(openModalButton).toBeInTheDocument()
 
     await user.click(openModalButton)
 
     expect(
-      screen.getByText('Are you sure you’d like to delete this section?')
+      screen.getByText('Are you sure you’d like to delete this widget?')
     ).toBeInTheDocument()
 
     const deleteButton = screen.getByText('Delete')

--- a/src/stores/modalContext.tsx
+++ b/src/stores/modalContext.tsx
@@ -180,7 +180,7 @@ export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
 
   const onDelete = () => {
     switch (modalId) {
-      case 'removeNewsSectionModal':
+      case 'removeNewsWidgetModal':
         trackEvent('Section settings', 'Remove this section', 'News')
         handleRemoveWidget({
           variables: { _id: widgetState?._id },
@@ -188,7 +188,7 @@ export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
         })
         closeModal()
         break
-      case 'removeGuardianIdealSectionModal':
+      case 'removeGuardianIdealWidgetModal':
         trackEvent(
           'Guardian Ideal Carousel',
           'Click on remove Ideal carousel',
@@ -200,7 +200,7 @@ export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
         })
         closeModal()
         break
-      case 'removeFeaturedShortcutsSectionModal':
+      case 'removeFeaturedShortcutsWidgetModal':
         trackEvent(
           'Featured Shortcuts Section',
           'Click on remove Featured Shortcuts',

--- a/src/stories/type.stories.tsx
+++ b/src/stories/type.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import type { Meta } from '@storybook/react'
-import { background } from '@storybook/theming'
 
 export default {
   title: 'Global/Typography',


### PR DESCRIPTION
# SC-419

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
- Add Section now reads Add widget
- Add News Section now reads Add News widget
- Add Featured Shortcuts Section now reads Add Featured Shortcuts widget
- Add Guardian Ideal Section now reads Add Guardian Ideal widget
- Update variable names that use 'section' to use 'widget'
- Update modals to use the word 'widget'
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Run the app locally:
- Add/remove widgets from MySpace. All references of 'section' should now be 'widget'
- Check out the e2e tests: https://github.com/USSF-ORBIT/ussf-portal/pull/267
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots
![Screenshot 2023-04-26 at 12 50 48 PM](https://user-images.githubusercontent.com/99674188/234661293-5e45d827-616c-42b4-8437-af657f74ea70.png)
![Screenshot 2023-04-26 at 12 51 35 PM](https://user-images.githubusercontent.com/99674188/234661558-fb3e18b2-86b8-4c0d-b850-b28135080a35.png)
![Screenshot 2023-04-26 at 12 51 47 PM](https://user-images.githubusercontent.com/99674188/234661577-3e1499b1-e29d-4b7b-8d61-03f2efe38587.png)
![Screenshot 2023-04-26 at 12 51 59 PM](https://user-images.githubusercontent.com/99674188/234661590-2d13d771-82be-4bf2-ae79-34610cf9b045.png)

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
