### PR TITLE
build: error on no-console unless approved method

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -35,7 +35,34 @@
     "jest"
   ],
   "rules": {
-    "no-console": "off",
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "assert",
+          "clear",
+          "count",
+          "countReset",
+          "debug",
+          "dir",
+          "dirxml",
+          "error",
+          "group",
+          "groupCollapsed",
+          "groupEnd",
+          "info",
+          "profile",
+          "profileEnd",
+          "table",
+          "time",
+          "timeEnd",
+          "timeLog",
+          "timeStamp",
+          "trace",
+          "warn"
+        ]
+      }
+    ],
     "security/detect-object-injection": "error",
     "import/no-useless-path-segments": "warn",
     "import/no-cycle": "error",

--- a/src/apolloClient.tsx
+++ b/src/apolloClient.tsx
@@ -11,7 +11,6 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
     graphQLErrors.forEach(({ message, locations, path, extensions }) => {
       // TODO - log error
-      // eslint-disable-next-line no-console
       console.error(
         `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
       )
@@ -29,7 +28,6 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 
   if (networkError) {
     // TODO - log error
-    // eslint-disable-next-line no-console
     console.error(`[Network error]: ${networkError}`)
   }
 })

--- a/src/components/DropdownFilter/DropdownFilter.stories.tsx
+++ b/src/components/DropdownFilter/DropdownFilter.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import type { Meta } from '@storybook/react'
-import { DropdownFilter } from './DropdownFilter'
 import styles from '../../styles/pages/sitesAndApplications.module.scss'
+import { DropdownFilter } from './DropdownFilter'
 export default {
   title: 'Base/DropdownFilter',
   component: DropdownFilter,

--- a/src/lib/keystoneClient.ts
+++ b/src/lib/keystoneClient.ts
@@ -11,7 +11,6 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (graphQLErrors)
     graphQLErrors.forEach(({ message, locations, path }) => {
       // TODO - log error
-      // eslint-disable-next-line no-console
       console.error(
         `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`
       )
@@ -19,7 +18,6 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 
   if (networkError) {
     // TODO - log error
-    // eslint-disable-next-line no-console
     console.error(`[Network error]: ${networkError}`)
   }
 })

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -8,11 +8,9 @@ export default redisClient
 
 redisClient.on('error', function (err) {
   // TODO - error handling
-  // eslint-disable-next-line no-console
   console.error('Could not connect to redis', err)
 })
 
 redisClient.on('connect', function () {
-  // eslint-disable-next-line no-console
-  console.log('Connected to Redis successfully')
+  console.info('Connected to Redis successfully')
 })

--- a/src/lib/requireAuth.ts
+++ b/src/lib/requireAuth.ts
@@ -59,7 +59,6 @@ export const requireAuth = (getServerSidePropsFunc?: GetServerSideProps) => {
       }
     } catch (e) {
       // TODO - handle the error
-      // eslint-disable-next-line no-console
       console.error('error getting session', e)
 
       return {

--- a/src/lib/saml.ts
+++ b/src/lib/saml.ts
@@ -147,7 +147,6 @@ export const configSaml = async (passport: PassportWithLogout) => {
     }
   } catch (err) {
     // TODO - log error
-    // eslint-disable-next-line no-console
     console.error(`Error loading SAML metadata from URL ${IDP_METADATA}`, err)
     throw err
   }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -36,7 +36,6 @@ const session: Middleware<NextApiRequest, NextApiResponse> = async (
     await getSession(req, res)
     next()
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error('Error getting session', e)
     throw e
   }

--- a/src/models/Bookmark.ts
+++ b/src/models/Bookmark.ts
@@ -263,7 +263,6 @@ export const BookmarkModel = {
 
       return createdBookmark
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('BookmarkModel Error: error in addOne', e)
       throw e
     }

--- a/src/models/Collection.ts
+++ b/src/models/Collection.ts
@@ -54,7 +54,6 @@ export const CollectionModel = {
         (w) => w.type === WIDGET_TYPES.COLLECTION
       ) as Collection[]
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('CollectionModel Error: error in getAll', e)
       throw e
     }
@@ -101,7 +100,6 @@ export const CollectionModel = {
       await db.collection('users').updateOne(query, updateDocument)
       return newCollection
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('CollectionModel Error: error in addOne', e)
       throw e
     }
@@ -151,7 +149,6 @@ export const CollectionModel = {
       await db.collection('users').updateOne(query, updateDocument)
       return newCollections
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('CollectionModel Error: error in addMany', e)
       throw e
     }
@@ -189,7 +186,6 @@ export const CollectionModel = {
 
       return updatedCollection
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('CollectionModel Error: error in editOne', e)
       throw e
     }
@@ -219,7 +215,6 @@ export const CollectionModel = {
       // Return deleted collection id
       return { _id }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('CollectionModel Error: error in deleteOne', e)
       throw e
     }

--- a/src/models/MySpace.ts
+++ b/src/models/MySpace.ts
@@ -26,7 +26,6 @@ export const MySpaceModel = {
       const user = await db.collection('users').findOne({ userId })
       return user.mySpace
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('MySpaceModel Error: error in get', e)
       throw e
     }
@@ -95,7 +94,6 @@ export const MySpaceModel = {
 
       return created
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('MySpaceModel Error: error in addOne', e)
       throw e
     }
@@ -118,7 +116,6 @@ export const MySpaceModel = {
         throw new Error('MySpaceModel Error: Document not updated')
       return { _id, type: 'News' }
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('MySpaceModel Error: error in deleteOne', e)
       throw e
     }

--- a/src/pages/api/auth/[[...action]].ts
+++ b/src/pages/api/auth/[[...action]].ts
@@ -12,11 +12,9 @@ import { configSaml, PassportRequest } from '../../../lib/saml'
 
 const handler = NextConnect<PassportRequest, NextApiResponse>({
   onError: (err, req, res) => {
-    /* eslint-disable no-console */
     console.error('Error in authentication')
     console.error(err)
     console.error(err.stack)
-    /* eslint-enable no-console */
     res.status(500).end('Error authenticating')
   },
 })
@@ -85,12 +83,10 @@ handler.get('/api/auth/logout', async (req, res) => {
         }
       } else if (err) {
         // TODO - error handling
-        // eslint-disable-next-line no-console
         console.error('Error initiating SLO request', err)
         res.status(500).end()
       } else {
         // TODO - error handling
-        // eslint-disable-next-line no-console
         console.error('Error initiating SLO request, missing request URL')
         res.status(500).end()
       }

--- a/src/stores/analyticsContext.tsx
+++ b/src/stores/analyticsContext.tsx
@@ -56,7 +56,7 @@ export const AnalyticsProvider = ({
     }
 
     if (debug === true) {
-      console.log(`ANALYTICS:`, ...args)
+      console.debug(`ANALYTICS:`, ...args)
     }
 
     windowWithAnalytics._paq.push(args)

--- a/src/stores/authContext.tsx
+++ b/src/stores/authContext.tsx
@@ -45,7 +45,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       setUser(null)
       window.location.href = '/login'
     } catch (e) {
-      // eslint-disable-next-line no-console
       console.error('Error logging out', e)
       // TODO - fix CORS error when logging out of test IDP
     }

--- a/src/stores/launchDarklyContext.tsx
+++ b/src/stores/launchDarklyContext.tsx
@@ -13,14 +13,12 @@ export const LaunchDarkly = ({ children }: { children: React.ReactNode }) => {
         if (data && data.clientSideID) {
           setClientSideID(data.clientSideID)
         } else {
-          // eslint-disable-next-line no-console
           console.error('issue retrieving the clientSideID')
         }
       }
 
       fetchClientSideID()
         // Catch error in fetching the id
-        // eslint-disable-next-line no-console
         .catch(console.error)
     }
   }, [clientSideID])

--- a/startup/logging.js
+++ b/startup/logging.js
@@ -76,7 +76,8 @@ function setUpLogging() {
   const loggingProperties = ['log', 'debug', 'info', 'warn', 'error']
   for (const property of loggingProperties) {
     // property is coming from loggingProperties which is a hard coded array
-    // eslint-disable-next-line security/detect-object-injection
+    // allowing console here since it is adding to the functionality of server side logs
+    // eslint-disable-next-line no-console, security/detect-object-injection
     console[property] = getLoggingFunction(property)
   }
 

--- a/startup/migrate.js
+++ b/startup/migrate.js
@@ -11,10 +11,10 @@ function runMigrations() {
         throw err
       }
 
-      console.log('[MIGRATION] Run migrations')
+      console.info('[MIGRATION] Run migrations')
 
       set.on('migration', function (migration, direction) {
-        console.log(`[MIGRATION - ${direction}] ${migration.title}`)
+        console.info(`[MIGRATION - ${direction}] ${migration.title}`)
       })
 
       set.up(function (err) {
@@ -22,7 +22,7 @@ function runMigrations() {
           throw err
         }
 
-        console.log('[MIGRATION] Migrations successful')
+        console.info('[MIGRATION] Migrations successful')
       })
     }
   )

--- a/utils/mongodb.js
+++ b/utils/mongodb.js
@@ -34,7 +34,7 @@ module.exports.runMigration = (migration) => async () => {
     await migration(db)
     await connection.close()
   } catch (e) {
-    console.log('[MIGRATION] Error with db connection', e)
+    console.error('[MIGRATION] Error with db connection', e)
     throw e
   }
 }


### PR DESCRIPTION
## Proposed changes

In accordance with [ADR 0021](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/adr/0021-disable-no-console-eslint-warning.md) this PR makes `console.log` a lint error but allows the other `console.*` methods. This PR also fixes the few legitimate uses of `console.log` with a more specific method like `console.warn` or `console.info`

## Reviewer notes

I left `console.debug` because I found one case where inside a `if (debug === true)` check we had a console log call and debug seemed the most appropriate method to use there.

## Setup

Run `yarn lint` with no errors and ensure system still works as expected

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria
- [ ] ~Created new stories in Storybook if applicable~
- [ ] ~Created/modified automated unit tests in Jest~
- [ ] ~Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)~
- [ ] ~Followed guidelines for zero-downtime deploys, if applicable~
- [ ] ~Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues~

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.