### PR TITLE
build: update DoD PKI Bundle to v5.12

### DIFF
--- a/scripts/add-dod-cas.sh
+++ b/scripts/add-dod-cas.sh
@@ -10,11 +10,11 @@
 
     # Extract the bundle
     cd /usr/local/share/ca-certificates
-    wget --no-check-certificate $bundle
+    wget $bundle
     unzip unclass-certificates_pkcs7_DoD.zip
 
     # check that Checksums verify
-    output=$(cd certificates_pkcs7_v5_11_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
+    output=$(cd certificates_pkcs7_v5_12_dod; sha256sum -c --strict ../dod_ca_cert_bundle.sha256)
     echo $output
     if [[ "$output" == *"FAILED"* ]]; then
         echo "Checksum failed" >&2
@@ -22,7 +22,7 @@
     fi
 
     # Convert the PKCS#7 bundle into individual PEM files
-    openssl pkcs7 -print_certs -in certificates_pkcs7_v5_11_dod/*_pem.p7b |
+    openssl pkcs7 -print_certs -in certificates_pkcs7_v5_12_dod/*_pem.p7b |
 
         awk 'BEGIN {c=0} /subject=/ {c++} {print > "cert." c ".pem"}'
 


### PR DESCRIPTION
Proposed changes

- The latest DoD PKI CA Certificates Bundle (PKCS#7) v5.12 has been released.](https://cyber.mil/announcement/new-dod-pki-cas-released/) and needs to be updated in our Docker build.
- The GH secret containing the sha256 hashes of the Bundle also has to be updated.
- Removed `--no-check-certificate` from wget command because the DoD PKI portal is no longer failing TLS check.

<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
