### PR TITLE
build: fix the team names

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -182,7 +182,7 @@ branches:
         users: []
         teams:
           [
-            '@USSF-ORBIT/design',
-            '@USSF-ORBIT/eng',
-            '@USSF-ORBIT/code-owners'
+            'USSF-ORBIT/design',
+            'USSF-ORBIT/eng',
+            'USSF-ORBIT/code-owners'
           ]


### PR DESCRIPTION
Update the team names in `.github/settings.yml` to see if that corrects the configuration issue.