### PR TITLE
fix: handle removed articles linked in announcements and missing articles for cms users

### DIFF
--- a/src/__fixtures__/data/cmsAnnouncments.ts
+++ b/src/__fixtures__/data/cmsAnnouncments.ts
@@ -190,3 +190,52 @@ export const testAnnouncementWithArticleNoSlug = {
   status: 'Published',
   publishedDate: '2022-05-17T13:44:39.796Z',
 }
+
+export const testAnnouncementWithDeletedArticle = {
+  id: 'anotherTest123',
+  title: 'Cool new deleted article',
+  body: {
+    document: [
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: 'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla consequat mas',
+          },
+        ],
+      },
+      {
+        type: 'component-block',
+        props: {
+          link: {
+            // missing article data, like when the article is deleted but the announcement still refers to it
+            value: {},
+            discriminant: 'article',
+          },
+          ctaText: 'View deleted article',
+        },
+        children: [
+          {
+            type: 'component-inline-prop',
+            children: [
+              {
+                text: '',
+              },
+            ],
+          },
+        ],
+        component: 'callToAction',
+      },
+      {
+        type: 'paragraph',
+        children: [
+          {
+            text: '',
+          },
+        ],
+      },
+    ],
+  },
+  status: 'Published',
+  publishedDate: '2022-05-17T13:44:39.796Z',
+}

--- a/src/components/AnnouncementInfo/AnnouncementInfo.test.tsx
+++ b/src/components/AnnouncementInfo/AnnouncementInfo.test.tsx
@@ -9,31 +9,45 @@ import AnnouncementInfo from './AnnouncementInfo'
 import {
   testAnnouncementWithArticle,
   testAnnouncementWithArticleNoSlug,
+  testAnnouncementWithDeletedArticle,
   testAnnouncementWithUrl,
 } from '__fixtures__/data/cmsAnnouncments'
 
 describe('AnnouncementInfo component', () => {
-  it('renders an announcement with a url CTA', () => {
+  test('renders an announcement with a url CTA', () => {
     render(<AnnouncementInfo announcement={testAnnouncementWithUrl} />)
 
     expect(screen.getAllByText('Test Announcement')).toHaveLength(1)
     expect(screen.getAllByText('View more')).toHaveLength(1)
   })
 
-  it('renders an announcement with a default url if none is provided', () => {
+  test('renders an announcement with a default url if none is provided', () => {
     render(
       <AnnouncementInfo announcement={testAnnouncementWithArticleNoSlug} />
     )
     expect(screen.getAllByText('Cool new article')).toHaveLength(1)
 
     const link = screen.getByRole('link', { name: 'View article' })
-    expect(link).toHaveAttribute('href', '/')
+    expect(link).toHaveAttribute('href', '/404')
   })
 
-  it('renders an announcement with an article CTA', () => {
+  test('renders an announcement with an article CTA', () => {
     render(<AnnouncementInfo announcement={testAnnouncementWithArticle} />)
 
     expect(screen.getAllByText('Cool new article')).toHaveLength(1)
     expect(screen.getAllByText('View article')).toHaveLength(1)
+    const link = screen.getByRole('link', { name: 'View article' })
+    expect(link).toHaveAttribute('href', '/articles/something')
+  })
+
+  test('renders an announcement with a missing article CTA', () => {
+    render(
+      <AnnouncementInfo announcement={testAnnouncementWithDeletedArticle} />
+    )
+
+    expect(screen.getAllByText('Cool new deleted article')).toHaveLength(1)
+    expect(screen.getAllByText('View deleted article')).toHaveLength(1)
+    const link = screen.getByRole('link', { name: 'View deleted article' })
+    expect(link).toHaveAttribute('href', '/404')
   })
 })

--- a/src/components/AnnouncementInfo/AnnouncementInfo.tsx
+++ b/src/components/AnnouncementInfo/AnnouncementInfo.tsx
@@ -27,9 +27,9 @@ const AnnouncementInfo = ({
           {props.link.discriminant === 'article' && (
             <LinkTo
               href={
-                props.link.value.data.slug
+                props.link.value.data?.slug
                   ? `/articles/${props.link.value.data.slug}`
-                  : '/'
+                  : '/404'
               }
               target="_blank"
               rel="noreferrer"

--- a/src/pages/articles/[article].tsx
+++ b/src/pages/articles/[article].tsx
@@ -52,11 +52,10 @@ const SingleArticlePage = ({
   article,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { user } = useUser()
-  const { category } = article
 
   return (
     <>
-      {category === 'ORBITBlog' ? (
+      {article?.category === 'ORBITBlog' ? (
         <ORBITBlogArticleHeader />
       ) : (
         <InternalNewsArticleHeader />
@@ -85,10 +84,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     variables: { slug },
   })
 
-  // if article is not published return 404
+  // if article is not published or not found return 404
   // unless the current user is a CMS user or admin
   // then allow them to see any article
-  if (!isPublished(article) && !isCmsUser(user)) {
+  if (!article || (!isPublished(article) && !isCmsUser(user))) {
     return {
       notFound: true,
     }


### PR DESCRIPTION
# SC-2007

And SC-2010

## Proposed changes

This PR fixes it so that announcements with a CTA button to a deleted article does not cause a 500 error. The button will send the user to a 404 page. SC-2007

This PR also fixes it so that when a CMS user goes to an article page that doesn't exist it does not cause a 500 error. It will now properly return a 404. SC-2010

## Reviewer notes

I did have to refactor the unit tests for the article page, as one of the tests would have caught the cms user 500 error if the mock had been properly setup.

## Setup

For SC-2007 Create a published article. Then create an announcement with a CTA button that points to that article. Finally delete the article and visit the landing page. The Announcement should show up, and the button will take you to the 404 page.

For SC-2010 Go to any article page that doesn't exist http://localhost:3000/articles/somefakeslug as a cms user and see the 404 page

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria
- [X] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

