### PR TITLE
fix: Fix drag-and-drop bug

### DIFF
--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -146,7 +146,10 @@ const CustomCollection = ({
   /** Add Link handlers */
 
   // Show the Add Link form
-  const handleShowAdding = () => setIsAddingLink(true)
+  const handleShowAdding = () => {
+    setIsAddingLink(true)
+    setDisableDragAndDrop(true)
+  }
 
   // Open Add Custom Link modal
   const openCustomLinkModal = () => {
@@ -158,6 +161,11 @@ const CustomCollection = ({
     updateWidget({ _id: _id, title: title, type: 'Collection' })
 
     updateCustomLinkLabel(customLabel, showAddWarning, isAddingLink)
+
+    // We have to disable drag and drop while users are adding/selecting a bookmark,
+    // so we need to enable it again here for collections when we open the modal and are
+    // no longer focused on the collection
+    setDisableDragAndDrop(false)
 
     modalRef?.current?.toggleModal(undefined, true)
   }
@@ -181,6 +189,7 @@ const CustomCollection = ({
       )
       handleAddBookmark(existingLink.url, existingLink.label, existingLink.id)
       setIsAddingLink(false)
+      setDisableDragAndDrop(false)
     }
   }
 
@@ -261,7 +270,10 @@ const CustomCollection = ({
               <Button
                 type="button"
                 unstyled
-                onClick={() => setIsAddingLink(false)}>
+                onClick={() => {
+                  setIsAddingLink(false)
+                  setDisableDragAndDrop(false)
+                }}>
                 Cancel
               </Button>
             </div>

--- a/src/components/CustomCollection/CustomCollection.tsx
+++ b/src/components/CustomCollection/CustomCollection.tsx
@@ -101,7 +101,7 @@ const CustomCollection = ({
     isAddingLinkContext,
     modalRef,
   } = useModalContext()
-  const { disableDragAndDrop, setDisableDragAndDrop } = useMySpaceContext()
+  const { setDisableDragAndDrop } = useMySpaceContext()
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -282,7 +282,6 @@ const CustomCollection = ({
   /* Collection settings handlers */
   // Toggle the dropdown menu
   const menuOnClick = () => {
-    setDisableDragAndDrop(!disableDragAndDrop)
     setIsDropdownOpen(!isDropdownOpen)
   }
 

--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useFlags } from 'launchdarkly-react-client-sdk'
 import { Grid } from '@trussworks/react-uswds'
-import { gql } from '@apollo/client'
 import { useRouter } from 'next/router'
 import {
   closestCorners,
@@ -172,35 +171,7 @@ const MySpace = ({ bookmarks }: { bookmarks: CMSBookmark[] }) => {
                                   title,
                                   bookmarks,
                                 },
-                                optimisticResponse: {
-                                  editCollection: {
-                                    _id: widget._id,
-                                    title,
-                                    bookmarks: bookmarks || widget.bookmarks,
-                                  },
-                                },
-                                update(cache, result) {
-                                  if (result.data?.editCollection) {
-                                    const { editCollection } = result.data
-                                    cache.writeFragment({
-                                      id: `Collection:${editCollection._id}`,
-                                      fragment: gql`
-                                        fragment collectionData on Collection {
-                                          _id
-                                          title
-                                          bookmarks {
-                                            _id
-                                            url
-                                            label
-                                            cmsId
-                                            isRemoved
-                                          }
-                                        }
-                                      `,
-                                      data: editCollection,
-                                    })
-                                  }
-                                },
+                                refetchQueries: [`getUser`],
                               })
                             }}
                             handleRemoveBookmark={(_id, cmsId) => {

--- a/src/hooks/useCloseWhenClickedOutside.ts
+++ b/src/hooks/useCloseWhenClickedOutside.ts
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react'
-import { useMySpaceContext } from 'stores/myspaceContext'
 export const useCloseWhenClickedOutside = (
   el: React.RefObject<HTMLElement>,
   initialState: boolean
 ) => {
   const [isActive, setIsActive] = useState(initialState)
-  const { disableDragAndDrop, setDisableDragAndDrop } = useMySpaceContext()
 
   useEffect(() => {
     const onClick = (e: MouseEvent) => {
@@ -13,7 +11,6 @@ export const useCloseWhenClickedOutside = (
         return
       }
 
-      setDisableDragAndDrop(!disableDragAndDrop)
       setIsActive(!isActive)
     }
 


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
In https://github.com/USSF-ORBIT/ussf-portal-client/pull/1056 we added the ability to drag and drop collections. We have discovered that when a user drags and drops a collection and then edits that collection, the collection moves back to where it was in the user's My Space originally. 

This fix simply removes the `optimisticResponse` and `update` options that were being passed to `handleEditCollection` and adds `refetchQueries[getUser]` to properly update the `MySpace` component after the drag and drop operation.

To do:
- ~Add e2e tests~
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Here are the e2e tests: https://github.com/USSF-ORBIT/ussf-portal/pull/302
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
