### PR TITLE
fix: use date from api for weather widget

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,7 +8,6 @@ module.exports = {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     'storybook-addon-mock',
-    'storybook-addon-launchdarkly',
   ],
   typescript: {
     check: false,

--- a/src/components/Loader/Loader.tsx
+++ b/src/components/Loader/Loader.tsx
@@ -13,7 +13,7 @@ const Loader = () => (
       <div className={styles.back}>
         <div className={styles.earth}></div>
         <div className={styles.cosmos}>
-          <div className={styles.star}></div>
+          <div className={styles.star} data-happo-hide></div>
           <div className={styles.spinner}>
             <div className={styles.face}>
               <div className={styles.circle}></div>

--- a/src/components/WeatherWidget/WeatherWidget.test.tsx
+++ b/src/components/WeatherWidget/WeatherWidget.test.tsx
@@ -1,11 +1,13 @@
 /**
  * @jest-environment jsdom
  */
+import axios from 'axios'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { ObjectId } from 'mongodb'
 import { renderWithMySpaceAndModalContext } from '../../testHelpers'
+import { mockHourlyForecast } from '__fixtures__/data/hourlyForecast'
 import WeatherWidget from './WeatherWidget'
 import { WeatherWidget as WeatherWidgetType } from 'types'
 
@@ -25,6 +27,14 @@ const mockWeatherWidget: WeatherWidgetType = {
   },
 }
 
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+beforeEach(() => {
+  mockedAxios.get.mockClear()
+})
+
 const mockWeatherWidgetWithIncorrectZipcode: WeatherWidgetType = {
   _id: ObjectId(),
   type: 'Weather',
@@ -41,6 +51,10 @@ const mockWeatherWidgetWithIncorrectZipcode: WeatherWidgetType = {
 }
 
 describe('WeatherWidget', () => {
+  mockedAxios.get.mockImplementation(() => {
+    return Promise.resolve({ data: mockHourlyForecast })
+  })
+
   test('renders the WeatherWidget component', async () => {
     await act(async () => {
       renderWithMySpaceAndModalContext(
@@ -52,6 +66,9 @@ describe('WeatherWidget', () => {
     await waitFor(() => {
       expect(screen.getByText('Weather')).toBeInTheDocument()
       expect(screen.getByText('Beverly Hills, CA')).toBeInTheDocument()
+      // this date is hardcoded in the fixture
+      expect(screen.getByText('Wed, Aug 16')).toBeInTheDocument()
+      expect(screen.getByText('74°')).toBeInTheDocument()
     })
   })
 

--- a/src/components/WeatherWidget/WeatherWidget.test.tsx
+++ b/src/components/WeatherWidget/WeatherWidget.test.tsx
@@ -31,10 +31,6 @@ jest.mock('axios')
 
 const mockedAxios = axios as jest.Mocked<typeof axios>
 
-beforeEach(() => {
-  mockedAxios.get.mockClear()
-})
-
 const mockWeatherWidgetWithIncorrectZipcode: WeatherWidgetType = {
   _id: ObjectId(),
   type: 'Weather',
@@ -51,8 +47,11 @@ const mockWeatherWidgetWithIncorrectZipcode: WeatherWidgetType = {
 }
 
 describe('WeatherWidget', () => {
-  mockedAxios.get.mockImplementation(() => {
-    return Promise.resolve({ data: mockHourlyForecast })
+  beforeEach(() => {
+    mockedAxios.get.mockClear()
+    mockedAxios.get.mockImplementation(() => {
+      return Promise.resolve({ data: mockHourlyForecast })
+    })
   })
 
   test('renders the WeatherWidget component', async () => {
@@ -235,6 +234,10 @@ describe('WeatherWidget', () => {
     const user = userEvent.setup()
     const mockConsoleError = jest.fn()
     jest.spyOn(console, 'error').mockImplementation(mockConsoleError)
+
+    mockedAxios.get.mockImplementation(() => {
+      return Promise.reject(new Error('Network Error'))
+    })
 
     renderWithMySpaceAndModalContext(
       <WeatherWidget widget={mockWeatherWidgetWithIncorrectZipcode} />

--- a/src/components/WeatherWidget/WeatherWidget.tsx
+++ b/src/components/WeatherWidget/WeatherWidget.tsx
@@ -149,9 +149,6 @@ const WeatherWidget = (widget: WeatherWidgetProps) => {
     setZipCode(sanitizedInput)
   }
 
-  const now = DateTime.now()
-  const currentDate = `${now.weekdayShort}, ${now.monthShort} ${now.day}`
-
   // Toggle the dropdown menu
   const menuOnClick = () => {
     setIsDropdownOpen(!isDropdownOpen)
@@ -317,7 +314,11 @@ const WeatherWidget = (widget: WeatherWidgetProps) => {
                   <div className={styles.shortForecast}>
                     <h4>{currentForecast[0].temperature}&deg;</h4>
                     <p>{currentForecast[0].shortForecast}</p>
-                    <p>{currentDate}</p>
+                    <p>
+                      {DateTime.fromISO(currentForecast[0].startTime).toFormat(
+                        'EEE, MMM d'
+                      )}
+                    </p>
                   </div>
                 </div>
 


### PR DESCRIPTION
## Proposed changes

The weather widget was using the current date for displaying the month and day in the weather widget. This PR changes it to use the date in the forecast response. Also this PR changes the unit test to mock the call to the api.

Also this PR uses the special attribute `data-happo-hide` on the star field in the loader as described in the [happo docs on spurious diffs](https://docs.happo.io/docs/spurious-diffs) to hide the star field from happo. The star field is randomly generated each build so it will always be different in each build.

## Reviewer notes

The fixtures used have a hard coded date of Aug 16th, 2023 which was a Wednesday. This is reflected in the unit test conditions I added and in the storybook renderings, see screenshot below.

## Setup

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

![SCR-20230911-ezm](https://github.com/USSF-ORBIT/ussf-portal-client/assets/940173/8a2a052d-e6a9-4eae-8098-11aa33b7959b)
