### PR TITLE
fix: a11y: removes raw link output from search results

### DIFF
--- a/src/components/ArticleListItem/ArticleListItem.module.scss
+++ b/src/components/ArticleListItem/ArticleListItem.module.scss
@@ -1,13 +1,17 @@
 @use 'uswds-core' as *;
 @use 'styles/sfds/index.scss' as *;
 .articleTitle {
-  margin-bottom: 0.5em;
   margin-top: 0;
+  margin-bottom: 0;
 
   a {
     color: var(--text);
     text-decoration: none;
   }
+}
+
+.listItemContent {
+  margin-top: units(1);
 }
 
 .categoryAndLabel {

--- a/src/components/ArticleListItem/ArticleListItem.test.tsx
+++ b/src/components/ArticleListItem/ArticleListItem.test.tsx
@@ -39,10 +39,6 @@ describe('ArticleListItem component', () => {
     expect(screen.getByText('17')).toBeInTheDocument()
 
     expect(screen.getAllByText(cmsTestArticle.title)).toHaveLength(1)
-    expect(screen.getByTestId('article-slug')).toHaveAttribute(
-      'href',
-      `/articles/${cmsTestArticle.slug}`
-    )
     expect(screen.getByText(cmsTestArticle.preview)).toBeInTheDocument()
     expect(screen.getByText('CMS Test Label')).toBeInTheDocument()
   })

--- a/src/components/ArticleListItem/ArticleListItem.tsx
+++ b/src/components/ArticleListItem/ArticleListItem.tsx
@@ -41,7 +41,7 @@ export const ArticleListItem = ({
               {title}
             </LinkTo>
           </h3>
-          <p>
+          <p className={styles.listItemContent}>
             <span className={styles.previewText}>{preview}</span>
           </p>
           <Grid row gap={4} className={styles.categoryAndLabel}>

--- a/src/components/ArticleListItem/ArticleListItem.tsx
+++ b/src/components/ArticleListItem/ArticleListItem.tsx
@@ -41,13 +41,6 @@ export const ArticleListItem = ({
               {title}
             </LinkTo>
           </h3>
-          <LinkTo
-            href={sourceLink ? sourceLink : `/articles/${slug}`}
-            target="_blank"
-            rel="noreferrer noopener"
-            data-testid="article-slug">
-            {sourceLink ? sourceLink : `/articles/${slug}`}
-          </LinkTo>
           <p>
             <span className={styles.previewText}>{preview}</span>
           </p>

--- a/src/components/SearchResultItem/SearchResultItem.module.scss
+++ b/src/components/SearchResultItem/SearchResultItem.module.scss
@@ -15,6 +15,7 @@
       color: inherit;
       text-decoration: none;
     }
+    margin-bottom: units(1);
   }
 
   h3 + a {

--- a/src/components/SearchResultItem/SearchResultItem.test.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.test.tsx
@@ -41,7 +41,7 @@ describe('SearchResultItem component', () => {
       )
 
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
-      expect(screen.queryAllByRole('link')).toHaveLength(2)
+      expect(screen.queryAllByRole('link')).toHaveLength(1)
       expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
         'href',
         testApplicationResult.permalink
@@ -71,7 +71,7 @@ describe('SearchResultItem component', () => {
       expect(screen.queryByText('17')).toBeInTheDocument()
 
       expect(screen.queryByRole('img')).not.toBeInTheDocument()
-      expect(screen.queryAllByRole('link')).toHaveLength(2)
+      expect(screen.queryAllByRole('link')).toHaveLength(1)
       expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
         'href',
         testArticleResult.permalink

--- a/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.tsx
@@ -36,11 +36,6 @@ export const SearchResultItem = ({ item }: { item: SearchResultRecord }) => {
           </LinkTo>
         </h3>
 
-        <LinkTo href={permalink} target="_blank" rel="noreferrer noopener">
-          {permalink}
-          <span className="usa-sr-only">(opens in a new window)</span>
-        </LinkTo>
-
         <p>{preview}</p>
 
         <div className={styles.metadata}>


### PR DESCRIPTION
# SC-2312

## Proposed changes

This branch removes the string output of a raw link url from the search results and article list items. The header 3 is already linked, and in usability testing with screen reader users, the additional link named with the URL made for a painful experience navigating search results and articles. 

When the link is removed, it causes the paragraph element in the result to come very close to the h3. This branch also adds 8px of margin under the h3 to account for this, and ensures the spacing is consistent across both components.


## Setup

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000
http://localhost:3000/news-announcements
or search something

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

http://localhost:6006/?path=/story/components-articlelist--example-article-list
http://localhost:6006/?path=/story/components-searchresults--search-results

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<img width="1273" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/f86e216a-d83b-4278-b1d6-d48474c3d21d">

<img width="931" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/37c09a51-4676-41e7-85c9-1d0a8e35faeb">
