### PR TITLE
dev: Track base location

### DIFF
--- a/src/__tests__/pages/404.test.tsx
+++ b/src/__tests__/pages/404.test.tsx
@@ -77,6 +77,7 @@ describe('404 page', () => {
           setUserIdFn: jest.fn(),
           unsetUserIdFn: jest.fn(),
           trackEvent: mockTrackEvents,
+          trackBaseLocation: jest.fn(),
         }
       })
       renderWithAuth(<Custom404 />)

--- a/src/__tests__/pages/500.test.tsx
+++ b/src/__tests__/pages/500.test.tsx
@@ -79,6 +79,7 @@ describe('500 page', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
     render(<Custom500 />)

--- a/src/__tests__/pages/_error.test.tsx
+++ b/src/__tests__/pages/_error.test.tsx
@@ -101,6 +101,7 @@ describe('custom error page', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
     render(<CustomError />)
@@ -122,6 +123,7 @@ describe('custom error page', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
     render(<CustomError statusCode={404} />)

--- a/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
+++ b/src/components/FeaturedShortcuts/FeaturedShortcuts.test.tsx
@@ -84,6 +84,7 @@ describe('FeaturedShortcuts component', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
 

--- a/src/components/FeedbackCard/FeedbackCard.test.tsx
+++ b/src/components/FeedbackCard/FeedbackCard.test.tsx
@@ -40,6 +40,7 @@ describe('Feedback Card component', () => {
           setUserIdFn: jest.fn(),
           unsetUserIdFn: jest.fn(),
           trackEvent: mockTrackEvents,
+          trackBaseLocation: jest.fn(),
         }
       })
 

--- a/src/components/GuardianIdeal/GuardianIdealCarousel.test.tsx
+++ b/src/components/GuardianIdeal/GuardianIdealCarousel.test.tsx
@@ -98,6 +98,7 @@ describe('GuardianIdealCarousel component', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
 

--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -72,7 +72,12 @@ const MySpace = ({ bookmarks }: { bookmarks: CMSBookmark[] }) => {
     fetchData()
   }, [])
 
-  const { trackEvent } = useAnalytics()
+  const { trackEvent, trackBaseLocation } = useAnalytics()
+
+  if (user?.personnelData) {
+    trackBaseLocation(user.personnelData.BASE_LOC)
+  }
+
   const {
     mySpace,
     isCollection,

--- a/src/components/ThemeToggle/ThemeToggle.test.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.test.tsx
@@ -83,6 +83,7 @@ describe('calling hook functions', () => {
         setUserIdFn: jest.fn(),
         unsetUserIdFn: jest.fn(),
         trackEvent: mockTrackEvents,
+        trackBaseLocation: jest.fn(),
       }
     })
 

--- a/src/stores/analyticsContext.test.tsx
+++ b/src/stores/analyticsContext.test.tsx
@@ -284,6 +284,41 @@ describe('Analytics context', () => {
     expect(mockConsoleDebug).toHaveBeenCalledWith('ANALYTICS(unsetUserId)')
   })
 
+  test('calls trackBaseLocation', async () => {
+    const windowWithAnalytics = window as unknown as WindowWithAnalytics
+
+    expect(windowWithAnalytics._paq).toBeDefined()
+
+    const TestComponent = () => {
+      const { trackBaseLocation } = useAnalytics()
+      return (
+        <div>
+          <button
+            type="button"
+            onClick={() => trackBaseLocation('testBaseLocation')}>
+            Track base location
+          </button>
+        </div>
+      )
+    }
+
+    render(
+      <AnalyticsProvider debug>
+        <TestComponent />
+      </AnalyticsProvider>
+    )
+
+    const user = userEvent.setup()
+    await user.click(
+      screen.getByRole('button', { name: 'Track base location' })
+    )
+
+    expect(mockConsoleDebug).toHaveBeenCalledWith(
+      'ANALYTICS(trackBaseLocation):',
+      'testBaseLocation'
+    )
+  })
+
   describe('with config defined', () => {
     const windowWithAnalytics = window as unknown as typeof Window & {
       _paq: (number[] | string[] | number | string | boolean)[]

--- a/src/stores/analyticsContext.tsx
+++ b/src/stores/analyticsContext.tsx
@@ -21,6 +21,7 @@ export type AnalyticsContextType = {
   setUserIdFn: (userId: string) => void
   unsetUserIdFn: () => void
   trackEvent: TrackFn
+  trackBaseLocation: (baseLocation: string) => void
 }
 
 export const AnalyticsContext = createContext<AnalyticsContextType>({
@@ -34,6 +35,9 @@ export const AnalyticsContext = createContext<AnalyticsContextType>({
     return
   },
   trackEvent: /* istanbul ignore next */ () => {
+    return
+  },
+  trackBaseLocation: /* istanbul ignore next */ () => {
     return
   },
 })
@@ -111,6 +115,20 @@ export const AnalyticsProvider = ({
     push(pushParams)
   }
 
+  // Track base location
+  const trackBaseLocation = (baseLocation: string): void => {
+    if (debug === true) {
+      console.debug(`ANALYTICS(trackBaseLocation):`, baseLocation)
+    }
+
+    // Track base location of user:
+    // setCustomDimension is required
+    // the 1 here corresponds to the id of the created custom dimension in the Matomo dashboard
+    // baseLocation comes from the personnel data api
+    push(['setCustomDimension', 1, baseLocation])
+    push(['trackPageView'])
+  }
+
   const handleRouteChange = (url: string) => {
     if (previousPath) push(['setReferrerUrl', previousPath])
 
@@ -180,6 +198,7 @@ export const AnalyticsProvider = ({
     setUserIdFn,
     unsetUserIdFn,
     trackEvent,
+    trackBaseLocation,
   }
 
   return (


### PR DESCRIPTION
# SC-2259

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Add custom dimension to Matomo to track base location

TO DO:
- ~Add tests~
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Testing this will require a small amount of setup. Here is what you need to do:
- Once you have all services running, navigate to `http://localhost:8081` (Matomo)
- Click the cog icon in the top right 
![Screenshot 2023-09-13 at 10 14 40 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/36f6ab37-dd12-48c5-99a9-b82672365a9b)
- You should now be on the Administration page. Look at the left menu, click Websites and then Custom Dimensions 
![Screenshot 2023-09-13 at 10 16 06 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/4d0c29be-3177-46f2-969d-12b3eac0abed)
- You should see something that looks like this, although you shouldn't see CustomLocation yet. Click the big green button to create a new dimension. Make sure you are under VISIT DIMENSIONS 
![Screenshot 2023-09-13 at 10 17 34 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/14add39c-666f-469a-a55f-4dee0330ba5a)
- Now create a custom dimension. I called mine CustomLocation because a Locations dimension already exists by default in Matomo (and just in case you're wondering, I did try to override it, but the docs advise against doing that). When you are done naming your dimension, click the ACTIVE checkbox 
![Screenshot 2023-09-13 at 10 19 08 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/c15e196a-70b5-48f8-9ad4-a4a863ed683d)
![Screenshot 2023-09-13 at 10 21 10 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/9bcd34f9-3669-4e02-b6d3-2113e0aeb7e8)
- Now back at the Custom Dimensions page, you should see something like this. Take note of the `Id` field on the left. That is the number that is being reference in the `trackBaseLocation` function in the `analyticsContext` 
![Screenshot 2023-09-13 at 10 21 56 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/669a945c-166d-4aea-8ef2-e2d86e5862ec)
- Now navigate to `http://localhost:3000/` and perform a couple of actions (or at least make sure to go to the My Space page)
- Back in Matomo, click Dashboard up in the top right menu
- Look at the left side of the screen and click Visitors and you should see your custom dimension in the menu 
![Screenshot 2023-09-13 at 10 25 18 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/e09840f7-9771-47ee-b2a9-4faa9b7e1178)
- You should now see the user's base location 
![Screenshot 2023-09-13 at 10 26 13 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/e7b6f3d6-e18a-4fa6-bf82-785086b97464)


<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
