### PR TITLE
build: allow env var override the weather api endpoint

### DIFF
--- a/src/pages/api/dataSources/weather.ts
+++ b/src/pages/api/dataSources/weather.ts
@@ -2,7 +2,16 @@ import { RESTDataSource } from '@apollo/datasource-rest'
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache'
 
 class WeatherAPI extends RESTDataSource {
-  override baseURL = `https://api.weather.gov/points/`
+  // NOTE: we are checking here instead of startup/index.js as typically
+  // we want the real url. The env var is a temporary override for
+  // development and e2e testing purposes. We may eventually decide to
+  // have this in startup/index.js like our other configurations
+  // but this allows us to be backwards compatbile with existing deploy
+  // configurations.
+  override baseURL =
+    process.env.WEATHER_API_URL && process.env.WEATHER_API_URL != ''
+      ? process.env.WEATHER_API_URL
+      : `https://api.weather.gov/points/`
 
   constructor(options: { cache: KeyValueCache }) {
     super(options)


### PR DESCRIPTION
## Proposed changes

To support mocking out the weather API in our E2E tests this PR sets it up so that the weather api endpoint can be over ridden by an environment variable. I didn't want to require adding this to each of our environments right away, especially since it is only needed for the E2E tests. We can switch to only the environment var in the future after this and remove the conditional and add the new var to the list in `startup/index.js` file.

## Reviewer notes

If you want to use the mocked service locally add the following to your `.envrc.local`. 

```sh
export WEATHER_API_URL=https://nws-ussf-e2e.wiremockapi.cloud/points/
```

⚠️ **NOTE** if you do this only the following zip codes are setup (aka stubbed) in the mock api. (90210, 85202, 85001, 30310, and 60601)

See also https://github.com/USSF-ORBIT/ussf-portal/pull/319

## Setup

Nothing should really be different. 

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.