### PR TITLE
fix: design: misc color adjustments in links & buttons

### DIFF
--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -92,7 +92,6 @@ $neutral-gray-800: #424242;
 $neutral-gray-900: #262626;
 $light-gray: #929292;
 $blue-gray: #71767a;
-$light-blue: #005ea2;
 $news-carousel: #161f2f;
 
 /** Taxonomy **/

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -120,7 +120,7 @@ $dark-gradient: linear-gradient(
   --dropdown-menu-bg-hover: #{$grey};
   --dropdown-menu-disabled-text: #070f1d50;
   --page-nav-link: #{$theme-ultraviolet-base};
-  --page-nav-link-after: #{$light-blue};
+  --page-nav-link-after: #{$theme-ultraviolet-base};
 
   // Widgets
   --widget-bg: #{$white};

--- a/src/styles/_themes.scss
+++ b/src/styles/_themes.scss
@@ -282,7 +282,7 @@ $dark-gradient: linear-gradient(
 
   --btn-primary-text: #{$theme-black};
 
-  --btn-logout-primary-bg: #{$theme-ultraviolet-muted-lighter};
+  --btn-logout-primary-bg: #{$theme-ultraviolet-lighter};
   --btn-logout-text: #{$black};
   --btn-logout-hover: #{$theme-ultraviolet-muted-lightest};
 

--- a/src/styles/sfds/index.scss
+++ b/src/styles/sfds/index.scss
@@ -223,7 +223,8 @@
     }
   }
 
-  .usa-button--accent-cool {
+  .usa-button--accent-cool,
+  .usa-menu-btn {
     background-color: $theme-ultraviolet-light;
     color: $theme-white;
 


### PR DESCRIPTION
# SC-2488

## Proposed changes

- changes log out button to have same color in both themes instead of slightly shifting color
- adds ussf blue to box next to active link in `PageNav` to replace uswds default
- removes unused light blue color from colors variables scss file
- changes menu button to use ussf blue instead of uswds default

## Reviewer notes

## Setup

Login to the portal http://localhost:3000

- see PageNav in My Space page - box next to active link should match link text color
- switch between dark mode and light mode, see there is no color change in the log out button background
- shrink screen size and see menu button matches other button styles more closely


### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

**Storybook not running locally for me.. direct links to components coming**

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

**PageNav**


<img width="271" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/6e2259ae-cb29-4400-8e1b-7f8f1ab4733c">



**menu button**


<img width="155" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/94c0af1f-45d8-4ecd-8306-05dad9837e09">



**log out button**


![logoutbutton](https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/3df9c6f3-f942-4f32-9db3-cdf1500d03da)



