### PR TITLE
fix: Wrap microsite link in an LD flag

### DIFF
--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -8,16 +8,16 @@ import React from 'react'
 import Footer from './Footer'
 
 describe('Footer component', () => {
-  it('renders the USSF portal header', () => {
+  test('renders the USSF portal header', () => {
     render(<Footer />)
 
     expect(
       screen.getByRole('img', { name: 'United States Space Force Logo' })
     ).toHaveAttribute('alt', 'United States Space Force Logo')
-    expect(screen.getAllByRole('link')).toHaveLength(16)
+    expect(screen.getAllByRole('link')).toHaveLength(15)
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -3,13 +3,15 @@ import {
   Footer as USWDSFooter,
   Logo as USWDSFooterLogo,
 } from '@trussworks/react-uswds'
-
+import { useFlags } from 'launchdarkly-react-client-sdk'
 import styles from './Footer.module.scss'
 
 import Logo from 'components/Logo/Logo'
 import LinkTo from 'components/util/LinkTo/LinkTo'
 
 const Footer = () => {
+  const flags = useFlags()
+
   return (
     <USWDSFooter
       className={styles.footer}
@@ -21,17 +23,23 @@ const Footer = () => {
             <br />
             <small>©2021 All rights reserved, ORBIT Space Force</small>
             <br />
-            <br />
-            <LinkTo
-              href="https://ussf-orbit.github.io/ussf-portal/"
-              target="_blank"
-              rel="noreferrer noopener"
-              id={styles.madeByLink}
-              aria-label="Made with love and code by ORBIT">
-              Made with ❤️&nbsp; and{' '}
-              <span className="font-body-lg">&lsaquo;&rsaquo;</span> by ORBIT{' '}
-              <span className="usa-sr-only">(opens in a new window)</span>
-            </LinkTo>
+
+            {flags?.microsite && (
+              <>
+                <br />
+                <LinkTo
+                  href="https://ussf-orbit.github.io/ussf-portal/"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                  id={styles.madeByLink}
+                  aria-label="Made with love and code by ORBIT">
+                  Made with ❤️&nbsp; and{' '}
+                  <span className="font-body-lg">&lsaquo;&rsaquo;</span> by
+                  ORBIT{' '}
+                  <span className="usa-sr-only">(opens in a new window)</span>
+                </LinkTo>
+              </>
+            )}
           </div>
 
           <div className="grid-col-fill" />

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -9,4 +9,5 @@ export default {
   searchPageFilter: true,
   dragAndDropCollections: true,
   weatherWidget: true,
+  microsite: false,
 }


### PR DESCRIPTION
# SC-2372

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Wrap link to microsite in an LD flag
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
I wrapped the entire display in a flag, but let me know if I only need to wrap the `href` instead. I just thought it might be confusing to a screenreader if the jsx was still present but the `href` didn't go anywhere.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
![false](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/93bd3f15-bece-44c2-b93c-765fbe84db6c)
![true](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/421fe2d5-cfc3-4e58-b27d-ca2ecd46eb3c)
