### PR TITLE
refactor: Update Matomo initialization

### DIFF
--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -74,10 +74,12 @@ const MySpace = ({ bookmarks }: { bookmarks: CMSBookmark[] }) => {
 
   const { trackEvent, trackBaseLocation, trackRank } = useAnalytics()
 
-  if (user?.personnelData) {
-    trackBaseLocation(user.personnelData.BASE_LOC)
-    trackRank(user.personnelData.Rank.Title)
-  }
+  useEffect(() => {
+    if (user?.personnelData) {
+      trackBaseLocation(user.personnelData.BASE_LOC)
+      trackRank(user.personnelData.Rank.Title)
+    }
+  }, [user?.personnelData])
 
   const {
     mySpace,

--- a/src/stores/analyticsContext.test.tsx
+++ b/src/stores/analyticsContext.test.tsx
@@ -318,7 +318,7 @@ describe('Analytics context', () => {
       'testBaseLocation'
     )
   })
-  
+
   test('calls trackRank', async () => {
     const windowWithAnalytics = window as unknown as WindowWithAnalytics
 
@@ -416,7 +416,7 @@ describe('Analytics context', () => {
         'setDocumentTitle',
         'Test Doc Title',
       ])
-      expect(windowWithAnalytics._paq[1]).toEqual(['setDoNotTrack', true])
+      expect(windowWithAnalytics._paq[1]).toEqual(['setDoNotTrack', false])
       expect(windowWithAnalytics._paq[2]).toEqual(['trackPageView'])
       expect(windowWithAnalytics._paq[3]).toEqual(['enableLinkTracking'])
       expect(windowWithAnalytics._paq[4]).toEqual([

--- a/src/stores/analyticsContext.tsx
+++ b/src/stores/analyticsContext.tsx
@@ -146,7 +146,7 @@ export const AnalyticsProvider = ({
     push(['setCustomDimension', 2, rank])
     push(['trackPageView'])
   }
-  
+
   const handleRouteChange = (url: string) => {
     if (previousPath) push(['setReferrerUrl', previousPath])
 
@@ -181,7 +181,7 @@ export const AnalyticsProvider = ({
       previousPath = location.href
 
       push(['setDocumentTitle', document.title])
-      push(['setDoNotTrack', true])
+      push(['setDoNotTrack', false])
       push(['trackPageView'])
       push(['enableLinkTracking'])
 


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
This PR 
- Changes the `setDoNotTrack` option in Matomo's initialization to `false`
- Move the calls to `trackRank` and `trackBaseLocation` into a `useEffect`
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
