### PR TITLE
fix: Open document in browser

### DIFF
--- a/src/helpers/openDocumentLink.ts
+++ b/src/helpers/openDocumentLink.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 export const isPdf = (url: string) => {
-  return url.toString().endsWith('.pdf')
+  return url.toString().includes('.pdf')
 }
 
 export const handleOpenPdfLink = async (pdfString: string) => {

--- a/src/models/MySpace.test.ts
+++ b/src/models/MySpace.test.ts
@@ -226,4 +226,21 @@ describe('My Space model', () => {
       MySpaceModel.deleteWidget({ _id: ObjectId(), userId: 'cat' }, { db })
     ).rejects.toThrow()
   })
+
+  test('can update widget order', async () => {
+    const originalOrder = await MySpaceModel.get({ userId: testUserId }, { db })
+
+    // Clone the array
+    const newOrder = Array.from(originalOrder)
+    // Move last item to first position
+    newOrder.unshift(newOrder.pop() as Widget)
+
+    const updated = await MySpaceModel.updateWidgetOrder(
+      { userId: testUserId, items: newOrder },
+      { db }
+    )
+
+    expect(updated).toBe(newOrder)
+    expect(updated).not.toBe(originalOrder)
+  })
 })


### PR DESCRIPTION
# SC-2436

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

* Changes `endsWith` to `includes` when checking an asset url for the `pdf` extension
* Adds a unit test to bump coverage

PDFs will now open in-browser. Other document formats will continue to download to a user's machine.

## Reviewer notes

In addition to the small code change, we need to update the CORS settings on the s3 bucket. This change has been made on dev, so the feature should now work as expected on dev.ussforbit.us. @jbecker01 Let me know when you're ready to test and I can double check that the branch is available on dev!

When we're ready to deploy, we'll also need @minhlai's assistance to make the changes on staging and prod.

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
