### PR TITLE
fix: redirect to cms on login

### DIFF
--- a/src/__tests__/pages/api/auth/[[...action]].test.ts
+++ b/src/__tests__/pages/api/auth/[[...action]].test.ts
@@ -88,7 +88,7 @@ describe('API / Auth handlers', () => {
         url: '/api/auth/login',
         test: async ({ fetch }) => {
           const res = await fetch({ method: 'POST', redirect: 'manual' })
-          expect(res.status).toBe(302)
+          expect(res.status).toBe(307)
           expect(res.cookies).toStrictEqual([
             expect.objectContaining({ sid: expect.any(String) }),
           ])

--- a/src/__tests__/pages/redirect.test.tsx
+++ b/src/__tests__/pages/redirect.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react'
+import { useRouter } from 'next/router'
+import axios from 'axios'
+
+import { renderWithAuth } from '../../testHelpers'
+
+import { cmsAnnouncementsMock as mockAnnouncements } from '../../__fixtures__/data/cmsAnnouncments'
+import { cmsPortalNewsArticlesMock as mockArticles } from '../../__fixtures__/data/cmsPortalNewsArticles'
+import { mockRssFeedTen } from '__mocks__/news-rss'
+import '../../__mocks__/mockMatchMedia'
+import * as useUserHooks from 'hooks/useUser'
+import { testPortalUser1, testUser1 } from '__fixtures__/authUsers'
+import { SessionUser } from 'types'
+import { GetUserQuery } from 'operations/portal/queries/getUser.g'
+import Redirect, { getServerSideProps } from 'pages/redirect'
+
+type MockedImplementation = {
+  user: SessionUser | null
+  portalUser: GetUserQuery | undefined
+  loading: boolean
+}
+
+jest.mock('../../lib/keystoneClient', () => ({
+  client: {
+    query: () => {
+      return {
+        data: {
+          announcements: mockAnnouncements,
+          articles: mockArticles,
+        },
+      }
+    },
+  },
+}))
+jest.mock('axios')
+
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn().mockReturnValue({
+    route: '',
+    pathname: '',
+    query: '',
+    asPath: '',
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}))
+
+const mockedUseRouter = useRouter as jest.Mock
+
+mockedUseRouter.mockReturnValue({
+  route: '',
+  pathname: '',
+  query: '',
+  asPath: '',
+  push: mockPush,
+  replace: mockReplace,
+})
+
+beforeEach(() => {
+  mockedAxios.get.mockClear()
+  jest
+    .spyOn(useUserHooks, 'useUser')
+    .mockImplementation((): MockedImplementation => {
+      return {
+        user: testUser1,
+        portalUser: testPortalUser1 as GetUserQuery,
+        loading: false,
+      }
+    })
+})
+
+describe('News page', () => {
+  describe('without a user', () => {
+    beforeEach(() => {
+      jest
+        .spyOn(useUserHooks, 'useUser')
+        .mockImplementation((): MockedImplementation => {
+          return {
+            user: null,
+            portalUser: undefined,
+            loading: true,
+          }
+        })
+
+      renderWithAuth(<Redirect redirectTo="" />, {})
+    })
+
+    test('renders the loader while fetching the user and does not fetch RSS items', () => {
+      expect(screen.getByText('Content is loading...')).toBeInTheDocument()
+    })
+  })
+
+  describe('when logged in', () => {
+    describe('getServerSideProps', () => {
+      test('returns correct props', async () => {
+        process.env.KEYSTONE_PUBLIC_URL = 'https://cms.example.com'
+        const context = {
+          query: {
+            redirectPath: '',
+          },
+        }
+        const response = await getServerSideProps(context)
+
+        expect(response).toEqual({
+          props: {
+            redirectTo: process.env.KEYSTONE_PUBLIC_URL,
+            pageTitle: 'Redirect',
+          },
+        })
+      })
+
+      test('returns correct props if redirectPath set', async () => {
+        process.env.KEYSTONE_PUBLIC_URL = 'https://cms.example.com'
+        const context = {
+          query: {
+            redirectPath: '/users',
+          },
+        }
+        const response = await getServerSideProps(context)
+
+        expect(response).toEqual({
+          props: {
+            redirectTo: `${process.env.KEYSTONE_PUBLIC_URL}/users`,
+            pageTitle: 'Redirect',
+          },
+        })
+      })
+
+      test('returns notFound if keystone url set to empty', async () => {
+        process.env.KEYSTONE_PUBLIC_URL = ''
+        const context = {
+          query: {
+            redirectPath: '/users',
+          },
+        }
+        const response = await getServerSideProps(context)
+
+        expect(response).toEqual({
+          notFound: true,
+        })
+      })
+    })
+
+    test('renders the page title and redirect content', async () => {
+      const expectedUrl = 'https://cms.example.com'
+      mockedAxios.get.mockImplementation(() => {
+        return Promise.resolve({ data: mockRssFeedTen })
+      })
+
+      renderWithAuth(<Redirect redirectTo="https://cms.example.com" />)
+
+      expect(screen.getByRole('link', { name: expectedUrl })).toBeVisible()
+      expect(screen.getByRole('link', { name: expectedUrl })).toHaveAttribute(
+        'href',
+        'https://cms.example.com'
+      )
+      expect(screen.getByRole('heading', { name: 'Redirect' })).toBeVisible()
+    })
+  })
+})

--- a/src/components/Redirect/Redirect.stories.tsx
+++ b/src/components/Redirect/Redirect.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Meta } from '@storybook/react'
+import { Redirect } from './Redirect'
+
+export default {
+  title: 'Components/Redirect',
+  component: Redirect,
+} as Meta
+
+export const Default = () => <Redirect redirectTo="http://example.com" />

--- a/src/components/Redirect/Redirect.test.tsx
+++ b/src/components/Redirect/Redirect.test.tsx
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { Redirect } from './Redirect'
+
+describe('Redirect component', () => {
+  test('renders the redirect', () => {
+    const expectedUrl = 'https://cms.example.com'
+    render(<Redirect redirectTo={expectedUrl} />)
+
+    expect(screen.getByRole('link', { name: expectedUrl })).toBeVisible()
+    expect(screen.getByRole('link', { name: expectedUrl })).toHaveAttribute(
+      'href',
+      'https://cms.example.com'
+    )
+    expect(screen.getByRole('heading', { name: 'Redirect' })).toBeVisible()
+  })
+})

--- a/src/components/Redirect/Redirect.tsx
+++ b/src/components/Redirect/Redirect.tsx
@@ -6,7 +6,7 @@ export const Redirect = ({ redirectTo }: { redirectTo: string }) => {
     <div>
       <h2>Redirect</h2>
       Please wait 5 seconds, while we redirect you to{' '}
-      <Link href={redirectTo}>{redirectTo}</Link>. If you are not redirected
+      <Link href={redirectTo}>{redirectTo}</Link>. If you are not redirected{' '}
       please click the link.
     </div>
   )

--- a/src/components/Redirect/Redirect.tsx
+++ b/src/components/Redirect/Redirect.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import Link from 'next/link'
+
+export const Redirect = ({ redirectTo }: { redirectTo: string }) => {
+  return (
+    <div>
+      <h2>Redirect</h2>
+      Please wait 5 seconds, while we redirect you to{' '}
+      <Link href={redirectTo}>{redirectTo}</Link>. If you are not redirected
+      please click the link.
+    </div>
+  )
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,5 @@
 // Pure functions that can be executed anywhere (NodeJS, browser)
 import { DateTime } from 'luxon'
-import { NextApiResponse } from 'next'
 import { PassportRequest } from 'lib/saml'
 
 import type {
@@ -88,10 +87,7 @@ export const getYouTubeEmbedId = (url: string) => {
   return embedId
 }
 
-export const handleRedirectTo = (
-  req: PassportRequest,
-  res: NextApiResponse
-) => {
+export const handleRedirectTo = (req: PassportRequest) => {
   // Login was successful, redirect back home
   // or redirect to redirectTo if passed in via RelayState
 
@@ -103,22 +99,28 @@ export const handleRedirectTo = (
       ? decodeURIComponent(req.body.RelayState)
       : '/'
 
+  console.debug(`incoming redirectTo: ${redirectTo}`)
   // check for valid places to redirect
   // 1. only allow relative paths e.g. `/news-announcements`
-  // 2. only allow url to cms `process.env.KEYSTONE_PUBLIC_URL`
+  // 2. only allow correct `/redirect` paths for the redirect page
   if (
-    redirectTo.startsWith('/cms') &&
+    redirectTo.startsWith('/redirect') &&
     process.env.KEYSTONE_PUBLIC_URL &&
     process.env.KEYSTONE_PUBLIC_URL !== ''
   ) {
-    const finalUrlToCMS = redirectTo.replace(
-      '/cms',
-      process.env.KEYSTONE_PUBLIC_URL
+    // This allows us to support `/redirect/somepath` to be turned into
+    // `/redirect?redirectPath=/somepath` which we use to support redirecting
+    // to a specific page within keystone. See redirect.tsx
+    const finalUrlTo = redirectTo.replace(
+      '/redirect',
+      '/redirect?redirectPath='
     )
-    res.redirect(302, finalUrlToCMS)
-  } else if (redirectTo !== '/cms' && redirectTo.startsWith('/')) {
-    res.redirect(302, redirectTo)
+    console.debug(`final redirectTo: ${finalUrlTo}`)
+    return finalUrlTo
+  } else if (redirectTo !== '/redirect' && redirectTo.startsWith('/')) {
+    console.debug(`final redirectTo: ${redirectTo}`)
+    return redirectTo
   } else {
-    res.redirect(302, '/')
+    return '/'
   }
 }

--- a/src/pages/api/auth/[[...action]].ts
+++ b/src/pages/api/auth/[[...action]].ts
@@ -44,15 +44,14 @@ handler.get('/api/auth/user', (req, res) => {
 handler.get('/api/auth/login', passport.authenticate('saml'))
 
 // POST /api/auth/login - callback URL for IdP SSO
-handler.post(
-  '/api/auth/login',
+handler.post('/api/auth/login', function (req, res, next) {
+  const redirectTo = handleRedirectTo(req)
   passport.authenticate('saml', {
     failureRedirect: '/login',
     failureMessage: true,
-  }),
-  // Login was successful, redirect the user
-  handleRedirectTo
-)
+    successRedirect: redirectTo,
+  })(req, res, next)
+})
 
 //  GET /api/auth/logout - initiate a SLO (logout) request
 handler.get('/api/auth/logout', async (req, res) => {

--- a/src/pages/redirect.tsx
+++ b/src/pages/redirect.tsx
@@ -1,10 +1,9 @@
-import Link from 'next/link'
-import styles from 'styles/pages/settings.module.scss'
 import { useUser } from 'hooks/useUser'
 import Loader from 'components/Loader/Loader'
 import { withArticleLayout } from 'layout/DefaultLayout/ArticleLayout'
+import { Redirect } from 'components/Redirect/Redirect'
 
-const Redirect = ({ redirectTo }: { redirectTo: string }) => {
+const RedirectPage = ({ redirectTo }: { redirectTo: string }) => {
   const { loading } = useUser()
 
   // we only want to redirect folks who are signed in
@@ -13,21 +12,14 @@ const Redirect = ({ redirectTo }: { redirectTo: string }) => {
   ) : (
     <>
       <meta httpEquiv="refresh" content={`5;URL='${redirectTo}'`} />
-      <div className={styles.settings}>
-        <div className={styles.widgetContainer}>
-          <h2 className={styles.pageTitle}>Redirect</h2>
-          Please wait 5 seconds, while we redirect you to{' '}
-          <Link href={redirectTo}>{redirectTo}</Link>. If you are not redirected
-          please click the link.
-        </div>
-      </div>
+      <Redirect redirectTo={redirectTo} />
     </>
   )
 }
 
-export default Redirect
+export default RedirectPage
 
-Redirect.getLayout = withArticleLayout
+RedirectPage.getLayout = withArticleLayout
 
 export async function getServerSideProps(context: {
   query: { redirectPath: string }
@@ -40,7 +32,7 @@ export async function getServerSideProps(context: {
   // Only allow url to cms `process.env.KEYSTONE_PUBLIC_URL`
   if (process.env.KEYSTONE_PUBLIC_URL !== '') {
     // check if we have a redirectPath and it's a relative path
-    if (redirectPath !== '' && redirectPath.startsWith('/')) {
+    if (redirectPath && redirectPath !== '' && redirectPath.startsWith('/')) {
       // create absolute path to keystone with redirectPath
       const finalUrlTo = `${process.env.KEYSTONE_PUBLIC_URL}${redirectPath}`
       return {

--- a/src/pages/redirect.tsx
+++ b/src/pages/redirect.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+import styles from 'styles/pages/settings.module.scss'
+import { useUser } from 'hooks/useUser'
+import Loader from 'components/Loader/Loader'
+import { withArticleLayout } from 'layout/DefaultLayout/ArticleLayout'
+
+const Redirect = ({ redirectTo }: { redirectTo: string }) => {
+  const { loading } = useUser()
+
+  // we only want to redirect folks who are signed in
+  return loading ? (
+    <Loader />
+  ) : (
+    <>
+      <meta httpEquiv="refresh" content={`5;URL='${redirectTo}'`} />
+      <div className={styles.settings}>
+        <div className={styles.widgetContainer}>
+          <h2 className={styles.pageTitle}>Redirect</h2>
+          Please wait 5 seconds, while we redirect you to{' '}
+          <Link href={redirectTo}>{redirectTo}</Link>. If you are not redirected
+          please click the link.
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default Redirect
+
+Redirect.getLayout = withArticleLayout
+
+export async function getServerSideProps(context: {
+  query: { redirectPath: string }
+}) {
+  const { redirectPath } = context.query
+  // This page is generically named but for now only redirects to the CMS
+  // we could pass in a parameter to redirect to other places if the need
+  // should arise.
+  //
+  // Only allow url to cms `process.env.KEYSTONE_PUBLIC_URL`
+  if (process.env.KEYSTONE_PUBLIC_URL !== '') {
+    // check if we have a redirectPath and it's a relative path
+    if (redirectPath !== '' && redirectPath.startsWith('/')) {
+      // create absolute path to keystone with redirectPath
+      const finalUrlTo = `${process.env.KEYSTONE_PUBLIC_URL}${redirectPath}`
+      return {
+        props: {
+          redirectTo: finalUrlTo,
+          pageTitle: 'Redirect',
+        },
+      }
+    } else {
+      // No redirect path send them to the root url
+      return {
+        props: {
+          redirectTo: process.env.KEYSTONE_PUBLIC_URL,
+          pageTitle: 'Redirect',
+        },
+      }
+    }
+  } else {
+    // if we don't know where to send them send them to the 404
+    return {
+      notFound: true,
+    }
+  }
+}


### PR DESCRIPTION
# SC-2743

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
This PR fixes the redirect process for when a user tries to go to the CMS first. This was introduced in https://github.com/USSF-ORBIT/ussf-portal-client/pull/1144. The change adds a redirect page that users are temporarily sent to in the portal which then redirects them to the cms after 5 seconds. The page also displays the link that the user is going to be redirected to in case the automatic one doesn't work.

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

Go to http://localhost:3001 and you should be redirected to the login flow and end on the cms page.

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
![SCR-20231120-sns](https://github.com/USSF-ORBIT/ussf-portal-client/assets/940173/9c2a1967-795c-45d1-8468-d9a4c3e6f84f)
