### PR TITLE
feat: Update breadcrumb display for articles

### DIFF
--- a/src/pages/landing/[landingPage]/[article]/index.tsx
+++ b/src/pages/landing/[landingPage]/[article]/index.tsx
@@ -17,9 +17,17 @@ const LandingPageArticle = ({
 
   // Use breadcrumbNavItems[2] to get the landing page name, replace hyphens with spaces
   // and convert to title case
-  const landingPageName = breadcrumbNavItems[2]
-    .replace(/-/g, ' ')
-    .replace(/\w\S*/g, (w) => w.replace(/^\w/, (c) => c.toUpperCase()))
+  let landingPageName = breadcrumbNavItems[2].replace(/-/g, ' ')
+
+  // If landingPageName has no spaces, it is probably an acronym, so convert to uppercase
+  if (!landingPageName.includes(' ')) {
+    landingPageName = landingPageName.toUpperCase()
+  } else {
+    landingPageName = landingPageName
+      .split(' ')
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ')
+  }
 
   return (
     <>


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
More consistent breadcrumbs for articles that are nested under a landing page
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
After https://github.com/USSF-ORBIT/ussf-portal-client/pull/1153 merged, I noticed that the breadcrumbs for an article would default to title case, and I don't think we want that for acronyms. An article with the path `http://localhost:3000/landing/cso/article-two` looked like this:
![Screenshot 2023-11-17 at 3 05 09 PM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/96318cb2-2b04-4e75-9398-921feb1bf99e)

This is what it looks like now:
![Screenshot 2023-11-17 at 3 03 22 PM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/6163eb54-42db-4a54-80a0-765e244dbabc)

And this is what it looks like with a path that contains hyphens. The path `http://localhost:3000/landing/deputy-chief-of-space/test-page` looks like this:
![Screenshot 2023-11-17 at 3 06 24 PM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/c79f2c28-494c-4bda-b881-0f70a7cd9d8d)

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
