### PR TITLE
chore(deps): renovate include storybook prefix and suffix pattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,10 +74,9 @@
     },
     {
       "description": ["Group updates for Storybook into a single PR"],
-      "extends": ["monorepo:storybook"],
       "groupName": "storybook",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackagePrefixes": ["@storybook", "storybook"],
+      "matchPackagePatterns": ["^@storybook", "^storybook", "storybook$"],
       "labels": ["storybook"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -77,7 +77,7 @@
       "extends": ["monorepo:storybook"],
       "groupName": "storybook",
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackagePrefixes": ["@storybook"],
+      "matchPackagePrefixes": ["@storybook", "storybook"],
       "labels": ["storybook"]
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -74,6 +74,7 @@
     },
     {
       "description": ["Group updates for Storybook into a single PR"],
+      "extends": "monorepo:storybook",
       "groupName": "storybook",
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePrefixes": ["@storybook"],

--- a/renovate.json
+++ b/renovate.json
@@ -74,7 +74,7 @@
     },
     {
       "description": ["Group updates for Storybook into a single PR"],
-      "extends": "monorepo:storybook",
+      "extends": ["monorepo:storybook"],
       "groupName": "storybook",
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePrefixes": ["@storybook"],


### PR DESCRIPTION
<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->
- This should fix the issue with storybook packages not matching the `@storybook` prefix

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
