### PR TITLE
feat: add lastLoginAt to user

### DIFF
--- a/src/__fixtures__/authUsers.ts
+++ b/src/__fixtures__/authUsers.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'bson'
+import { DateTime } from 'luxon'
 import type { SessionUser, PortalUser, Collection, Widget } from 'types'
 
 const mockNews: Widget = {
@@ -111,6 +112,7 @@ export const testPortalUser1: PortalUser = {
   ],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 export const portalUserMaxedOutCollection: PortalUser = {
@@ -156,6 +158,7 @@ export const portalUserMaxedOutCollection: PortalUser = {
   ],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 export const portalUserWithExampleCollection: PortalUser = {
@@ -194,6 +197,7 @@ export const portalUserWithExampleCollection: PortalUser = {
   ],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 const mockCollectionWithGuardianIdeal: Widget = {
@@ -207,6 +211,7 @@ export const portalUserGuardianIdeal: PortalUser = {
   mySpace: [mockCollectionWithGuardianIdeal],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'dark',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 const mockCollectionWithFeaturedShortcuts: Widget = {
@@ -220,6 +225,7 @@ export const portalUserFeaturedShortcuts: PortalUser = {
   mySpace: [mockCollectionWithFeaturedShortcuts],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'dark',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 const mockCollection: Collection = {
@@ -260,6 +266,7 @@ export const portalUserCollectionLimit: PortalUser = {
   mySpace: maxCollections,
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 export const portalUserAlmostAtCollectionLimit: PortalUser = {
@@ -267,6 +274,7 @@ export const portalUserAlmostAtCollectionLimit: PortalUser = {
   mySpace: almostMaxCollections,
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 export const portalUserCollectionLimitWithAllAdditionalWidgets: PortalUser = {
@@ -279,6 +287,7 @@ export const portalUserCollectionLimitWithAllAdditionalWidgets: PortalUser = {
   ],
   displayName: 'BERNADETTE CAMPBELL',
   theme: 'light',
+  lastLoginAt: DateTime.now().toISO()!,
 }
 
 export const portalUserNoCollections: PortalUser = {

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -294,5 +294,20 @@ describe('User model', () => {
       const updatedUser = await User.findOne('testUserId', { db })
       expect(updatedUser.lastLoginAt).toEqual(expectedUser.lastLoginAt)
     })
+
+    test('throws an error if user not found', async () => {
+      await expect(
+        User.setLastLoginAt(
+          {
+            userId: 'thisuserdoesnotexist',
+          },
+          {
+            db,
+          }
+        )
+      ).rejects.toThrow(
+        'UserModel Error: error in setLastLoginAt no user found'
+      )
+    })
   })
 })

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -6,9 +6,13 @@ import {
   exampleCollection1,
 } from '__fixtures__/newPortalUser'
 import { WIDGETS } from 'constants/index'
+import { DateTime, Settings } from 'luxon'
 
 let connection: typeof MongoClient
 let db: typeof Db
+
+// Set test time to specific time
+Settings.now = () => new Date('2024-01-01T10:11:03.000Z').valueOf()
 
 describe('User model', () => {
   beforeAll(async () => {
@@ -37,11 +41,47 @@ describe('User model', () => {
       ],
       displayName: 'Floyd King',
       theme: 'light',
+      lastLoginAt: DateTime.now().toISO(),
     }
 
     const displayName = 'Floyd King'
     await User.createOne(
       'testUserId',
+      [exampleCollection],
+      displayName,
+      'light',
+      { db },
+      DateTime.now()
+    )
+
+    const insertedUser = await User.findOne('testUserId', { db })
+
+    expect(insertedUser.userId).toBe(expectedUser.userId)
+    expect(insertedUser.displayName).toBe(expectedUser.displayName)
+    expect(insertedUser.theme).toBe(expectedUser.theme)
+    expect(insertedUser.mySpace[0].title).toContain(
+      expectedUser.mySpace[0].title
+    )
+    expect(insertedUser.lastLoginAt).toBe(expectedUser.lastLoginAt)
+  })
+
+  test('can create and find a new user without lastLoginAt', async () => {
+    const expectedUser = {
+      _id: expect.anything(),
+      userId: 'testUserId',
+      mySpace: [
+        WIDGETS.FEATUREDSHORTCUTS,
+        WIDGETS.GUARDIANIDEAL,
+        exampleCollection1,
+      ],
+      displayName: 'Floyd King',
+      theme: 'light',
+      lastLoginAt: DateTime.now().toISO(),
+    }
+
+    const displayName = 'Floyd King'
+    await User.createOne(
+      'testUserId2',
       [exampleCollection],
       displayName,
       'light',
@@ -56,6 +96,7 @@ describe('User model', () => {
     expect(insertedUser.mySpace[0].title).toContain(
       expectedUser.mySpace[0].title
     )
+    expect(insertedUser.lastLoginAt).toBe(expectedUser.lastLoginAt)
   })
 
   test('returns null if finding a user that doesn’t exist', async () => {
@@ -203,6 +244,55 @@ describe('User model', () => {
           }
         )
       ).rejects.toThrow('UserModel Error: error in setMySpace no user found')
+    })
+  })
+
+  describe('lastLoginAt', () => {
+    test('can update the lastLoginAt of a user if no time passed in', async () => {
+      const expectedUser = {
+        _id: expect.anything(),
+        userId: 'testUserId',
+        mySpace: [exampleCollection1],
+        theme: 'dark',
+        lastLoginAt: DateTime.now().toISO()!,
+      }
+
+      const { userId } = expectedUser
+      await User.setLastLoginAt(
+        {
+          userId,
+        },
+        {
+          db,
+        }
+      )
+
+      const updatedUser = await User.findOne('testUserId', { db })
+      expect(updatedUser.lastLoginAt).toEqual(expectedUser.lastLoginAt)
+    })
+
+    test('can update the lastLoginAt of a user', async () => {
+      const expectedUser = {
+        _id: expect.anything(),
+        userId: 'testUserId',
+        mySpace: [exampleCollection1],
+        theme: 'dark',
+        lastLoginAt: DateTime.now().toISO()!,
+      }
+
+      const { userId } = expectedUser
+      await User.setLastLoginAt(
+        {
+          userId,
+          lastLoginAt: DateTime.now(),
+        },
+        {
+          db,
+        }
+      )
+
+      const updatedUser = await User.findOne('testUserId', { db })
+      expect(updatedUser.lastLoginAt).toEqual(expectedUser.lastLoginAt)
     })
   })
 })

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -1,4 +1,5 @@
 import { Db, MongoClient } from 'mongodb'
+import { DateTime, Settings } from 'luxon'
 
 import User from './User'
 import {
@@ -6,7 +7,6 @@ import {
   exampleCollection1,
 } from '__fixtures__/newPortalUser'
 import { WIDGETS } from 'constants/index'
-import { DateTime, Settings } from 'luxon'
 
 let connection: typeof MongoClient
 let db: typeof Db

--- a/src/models/User.test.ts
+++ b/src/models/User.test.ts
@@ -68,7 +68,7 @@ describe('User model', () => {
   test('can create and find a new user without lastLoginAt', async () => {
     const expectedUser = {
       _id: expect.anything(),
-      userId: 'testUserId',
+      userId: 'testUserId2',
       mySpace: [
         WIDGETS.FEATUREDSHORTCUTS,
         WIDGETS.GUARDIANIDEAL,
@@ -88,7 +88,7 @@ describe('User model', () => {
       { db }
     )
 
-    const insertedUser = await User.findOne('testUserId', { db })
+    const insertedUser = await User.findOne('testUserId2', { db })
 
     expect(insertedUser.userId).toBe(expectedUser.userId)
     expect(insertedUser.displayName).toBe(expectedUser.displayName)

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,4 +1,5 @@
 import { Context } from '@apollo/client'
+import { DateTime } from 'luxon'
 
 import { CollectionModel } from './Collection'
 import { MySpaceModel } from './MySpace'
@@ -8,7 +9,6 @@ import type {
   WidgetInputType,
 } from 'types/index'
 import { WIDGETS } from 'constants/index'
-import { DateTime } from 'luxon'
 
 type EditDisplayName = {
   userId: string

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -3,6 +3,7 @@ import { ApolloServer } from '@apollo/server'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import { gql } from 'graphql-tag'
 import { GraphQLError } from 'graphql'
+import { DateTime } from 'luxon'
 import { typeDefs } from '../../schema'
 import WeatherAPI from './dataSources/weather'
 import KeystoneAPI from './dataSources/keystone'
@@ -14,7 +15,6 @@ import clientPromise from 'lib/mongodb'
 import { getSession } from 'lib/session'
 import User from 'models/User'
 import { EXAMPLE_COLLECTION_ID } from 'constants/index'
-import { DateTime } from 'luxon'
 
 // To create a new user, we need the example collection from Keystone
 const getExampleCollection = async () => {

--- a/src/pages/api/graphql.tsx
+++ b/src/pages/api/graphql.tsx
@@ -14,6 +14,7 @@ import clientPromise from 'lib/mongodb'
 import { getSession } from 'lib/session'
 import User from 'models/User'
 import { EXAMPLE_COLLECTION_ID } from 'constants/index'
+import { DateTime } from 'luxon'
 
 // To create a new user, we need the example collection from Keystone
 const getExampleCollection = async () => {
@@ -88,12 +89,22 @@ export default startServerAndCreateNextHandler(apolloServer, {
       // Check if user exists. If not, create new user
       const foundUser = await User.findOne(userId, { db })
 
-      if (!foundUser) {
+      const lastLoginAt = DateTime.now()
+      if (foundUser) {
+        await User.setLastLoginAt({ userId, lastLoginAt }, { db })
+      } else {
         try {
           const initCollection = await getExampleCollection()
-          await User.createOne(userId, [initCollection], displayName, 'light', {
-            db,
-          })
+          await User.createOne(
+            userId,
+            [initCollection],
+            displayName,
+            'light',
+            {
+              db,
+            },
+            lastLoginAt
+          )
         } catch (e) {
           // TODO log error
           // console.error('error in creating new user', e)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -304,6 +304,7 @@ export type PortalUser = {
   mySpace: (Widget | Collection)[]
   displayName: string
   theme: string
+  lastLoginAt: string
 }
 
 export type SessionUser = SAMLUser & {


### PR DESCRIPTION
# SC-2066

## Proposed changes

This PR adds a new field to the mongo user data called `lastLoginAt`. It is the date of the last login of a user stored as an ISO formatted string. This field is updated every time a user visits a page in the portal. As noted in the story we want to track the data in case we ever run into the duplicate user issue or if we decided to look at number of users active in some period of time.

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

This change is only in the back end. So the data will only be saved in Mongo but not displayed anywhere. Locally you can use Mongo Express to view it by going to http://localhost:8888/db/dev/users and viewing the user data.

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

Then view http://localhost:8888/db/dev/users to see that your record now has a `lastLoginAt` field correctly set. It will be updated every visit to the portal.

---

## Code review steps

### As the original developer, I have

- [X] Met the acceptance criteria
- [ ] ~Created new stories in Storybook if applicable~
- [X] Created/modified automated unit tests in Jest
- [ ] ~Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)~
- [X] Followed guidelines for zero-downtime deploys, if applicable
- [ ] ~Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues~

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

