### PR TITLE
feat: Add LoadingWidget to Guardian Directory page

### DIFF
--- a/src/pages/guardian-directory.tsx
+++ b/src/pages/guardian-directory.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useFlags } from 'launchdarkly-react-client-sdk'
 import { useRouter } from 'next/router'
 import { Button, Search } from '@trussworks/react-uswds'
+import LoadingWidget from 'components/LoadingWidget/LoadingWidget'
 import { useUser } from 'hooks/useUser'
 import { withDefaultLayout } from 'layout/DefaultLayout/DefaultLayout'
 import styles from 'styles/pages/guardianDirectory.module.scss'
@@ -82,27 +83,31 @@ const GuardianDirectory = () => {
           </Button>
         </div>
 
-        <GuardianDirectoryTable
-          headers={[
-            'Last Name',
-            'First Name',
-            'Rank',
-            'Title',
-            'Base',
-            'Field Commands',
-            'Email',
-          ]}
-          keys={[
-            'LastName',
-            'FirstName',
-            'Rank',
-            'DutyTitle',
-            'BaseLoc',
-            'MajCom',
-            'Email',
-          ]}
-          rows={directory}
-        />
+        {!directory.length ? (
+          <LoadingWidget />
+        ) : (
+          <GuardianDirectoryTable
+            headers={[
+              'Last Name',
+              'First Name',
+              'Rank',
+              'Title',
+              'Base',
+              'Field Commands',
+              'Email',
+            ]}
+            keys={[
+              'LastName',
+              'FirstName',
+              'Rank',
+              'DutyTitle',
+              'BaseLoc',
+              'MajCom',
+              'Email',
+            ]}
+            rows={directory}
+          />
+        )}
       </div>
     </>
   )

--- a/src/pages/guardian-directory.tsx
+++ b/src/pages/guardian-directory.tsx
@@ -10,8 +10,6 @@ import { useGetGuardianDirectoryQuery } from 'operations/portal/queries/getGuard
 import { useSearchGuardianDirectoryQuery } from 'operations/portal/queries/searchGuardianDirectory.g'
 import { GuardianDirectory as GuardianDirectoryType } from 'types'
 
-import Loader from 'components/Loader/Loader'
-
 const GuardianDirectory = () => {
   const flags = useFlags()
   const router = useRouter()
@@ -61,9 +59,7 @@ const GuardianDirectory = () => {
     router.replace('/404')
   }
 
-  return loading ? (
-    <Loader />
-  ) : (
+  return (
     <>
       <div className={styles.guardianDirectory}>
         <div className={styles.guardianDirectoryHeader}>


### PR DESCRIPTION
# SC-2984

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
Add the LoadingWidget to the Guardian Directory
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
Navigate to `http://localhost:3000/guardian-directory`

When running this locally, you probably won't see the loading state because of how few test fields there are. You can do one of two things:
- You can download the full spreadsheets from the GDrive, add them to your local ussf-personnel-api and update the docker-compose.services.yml file in this repo to point to your local personnel api.
- Or you can simply go to `src/pages/guardian-directory.tsx` and change `!directory.length` on line 86 to `true`. Save and reload the app to see the loading state.
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
![Screenshot 2024-01-03 at 11 13 40 AM](https://github.com/USSF-ORBIT/ussf-portal-client/assets/99674188/648dc98d-68f6-4a0d-8763-e7b6cb1721ef)
