### PR TITLE
feat: add landing pages to search results

### DIFF
--- a/src/__fixtures__/data/cmsSearch.ts
+++ b/src/__fixtures__/data/cmsSearch.ts
@@ -3,7 +3,7 @@ export const mockCmsSearchResults = [
     __typename: 'ArticleResult',
     type: 'Article',
     id: 'cl3buldda0247riyt6h85cpgc',
-    permalink: 'my-fitness-article',
+    permalink: 'http://example.com/article/my-fitness-article',
     title: 'My Fitness Article',
     preview: 'This is the preview text!',
     date: '2022-05-18T17:18:40.802Z',

--- a/src/__fixtures__/data/searchResults.ts
+++ b/src/__fixtures__/data/searchResults.ts
@@ -1,0 +1,49 @@
+import type { SearchResultRecord } from 'types/index'
+
+export const testApplicationResult: SearchResultRecord = {
+  id: 'testBookmark123',
+  type: 'Bookmark',
+  title: 'MyFSS',
+  preview:
+    'How is Air Force Information Management System abbreviated? AFIMS stands for Air Force Information Management System. For those who have seen the Earth from space, and for the hundreds and perhaps thousands more who will, the experience most certainly changes your perspective.',
+  permalink: 'https://www.url.com/myfss',
+}
+
+export const testDocumentationResult: SearchResultRecord = {
+  id: 'testDocumentation123',
+  type: 'Documentation',
+  title: 'Some Documentation',
+  preview:
+    'Documentation posted about some important topic that you should read about.',
+  permalink: 'https://localhost:3000/path/to/documentation',
+}
+
+export const testArticleResultNoLabels: SearchResultRecord = {
+  id: 'testArticle124',
+  type: 'Article',
+  title:
+    'Physical training: but without labels Everything you need to know about the update in requirements',
+  preview:
+    'There are no labels. As a steward of almost 9 million acres encompassing forests, prairies, deserts, wetlands, and coastal habitats, the Department of the Air Force recognizes the importance of protecting and sustaining the natural environment.',
+  permalink:
+    'https://localhost:3000/articles/physical-training-everything-you-need-to-know-no-labels',
+  date: '2022-05-17T13:44:39.796Z',
+}
+export const testArticleResult: SearchResultRecord = {
+  id: 'testArticle123',
+  type: 'Article',
+  title:
+    'Physical training: Everything you need to know about the update in requirements',
+  preview:
+    'As a steward of almost 9 million acres encompassing forests, prairies, deserts, wetlands, and coastal habitats, the Department of the Air Force recognizes the importance of protecting and sustaining the natural environment.',
+  permalink:
+    'https://localhost:3000/articles/physical-training-everything-you-need-to-know',
+  date: '2022-05-17T13:44:39.796Z',
+  labels: [
+    {
+      id: 'testLabel',
+      name: 'All Guardians',
+      type: 'Audience',
+    },
+  ],
+}

--- a/src/__fixtures__/data/searchResults.ts
+++ b/src/__fixtures__/data/searchResults.ts
@@ -18,6 +18,15 @@ export const testDocumentationResult: SearchResultRecord = {
   permalink: 'https://localhost:3000/path/to/documentation',
 }
 
+export const testLandingPageResult: SearchResultRecord = {
+  id: 'testLandingPage123',
+  type: 'LandingPage',
+  title: 'Some Landing Page',
+  preview:
+    'Our team landing page where you can find all the information you need to know about our team.',
+  permalink: 'https://localhost:3000/landing/team',
+}
+
 export const testArticleResultNoLabels: SearchResultRecord = {
   id: 'testArticle124',
   type: 'Article',

--- a/src/__tests__/pages/search.test.tsx
+++ b/src/__tests__/pages/search.test.tsx
@@ -72,13 +72,7 @@ describe('Search page getServerSideProps', () => {
       props: {
         query: 'fitness',
         pageTitle: 'fitness Search Results',
-        results: mockCmsSearchResults.map((r) => ({
-          ...r,
-          permalink:
-            r.type === 'Article'
-              ? `http://example.com/articles/${r.permalink}`
-              : r.permalink,
-        })),
+        results: mockCmsSearchResults,
       },
     })
   })

--- a/src/components/SearchResultItem/SearchResultItem.stories.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.stories.tsx
@@ -2,44 +2,20 @@ import React from 'react'
 import { Meta } from '@storybook/react'
 
 import { SearchResultItem } from './SearchResultItem'
-import type { SearchResultRecord } from 'types/index'
+import {
+  testArticleResult,
+  testApplicationResult,
+  testDocumentationResult,
+} from '__fixtures__/data/searchResults'
 
 export default {
   title: 'Components/SearchResults/SearchResultItem',
   component: SearchResultItem,
 } as Meta
 
-const testApplicationResult: SearchResultRecord = {
-  id: 'testBookmark123',
-  type: 'Bookmark',
-  title: 'MyFSS',
-  preview:
-    'How is Air Force Information Management System abbreviated? AFIMS stands for Air Force Information Management System. For those who have seen the Earth from space, and for the hundreds and perhaps thousands more who will, the experience most certainly changes your perspective.',
-  permalink: 'https://www.url.com/myfss',
-}
-
 export const ApplicationResult = () => (
   <SearchResultItem item={testApplicationResult} />
 )
-
-const testArticleResult: SearchResultRecord = {
-  id: 'testArticle123',
-  type: 'Article',
-  title:
-    'Physical training: Everything you need to know about the update in requirements',
-  preview:
-    'As a steward of almost 9 million acres encompassing forests, prairies, deserts, wetlands, and coastal habitats, the Department of the Air Force recognizes the importance of protecting and sustaining the natural environment.',
-  permalink:
-    'https://localhost:3000/articles/physical-training-everything-you-need-to-know',
-  date: '2022-05-17T13:44:39.796Z',
-  labels: [
-    {
-      id: 'testLabel',
-      name: 'All Guardians',
-      type: 'Audience',
-    },
-  ],
-}
 
 export const ArticleResult = () => <SearchResultItem item={testArticleResult} />
 
@@ -53,4 +29,8 @@ export const ArticleResultLineClamp = () => (
         'https://localhost:3000/articles/physical-training-everything-you-need-to-know?asfljaslfkjlkajrlakjsflkajsflasfmaaslkfjalsfjaklsjlasfksfljaslfkjlkajrlakjsflkajsflasfmaaslkfjalsfjaklsjlasfk',
     }}
   />
+)
+
+export const DocumentationResult = () => (
+  <SearchResultItem item={testDocumentationResult} />
 )

--- a/src/components/SearchResultItem/SearchResultItem.stories.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.stories.tsx
@@ -6,6 +6,7 @@ import {
   testArticleResult,
   testApplicationResult,
   testDocumentationResult,
+  testLandingPageResult,
 } from '__fixtures__/data/searchResults'
 
 export default {
@@ -33,4 +34,8 @@ export const ArticleResultLineClamp = () => (
 
 export const DocumentationResult = () => (
   <SearchResultItem item={testDocumentationResult} />
+)
+
+export const LandingPageResult = () => (
+  <SearchResultItem item={testLandingPageResult} />
 )

--- a/src/components/SearchResultItem/SearchResultItem.test.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.test.tsx
@@ -7,37 +7,11 @@ import { axe } from 'jest-axe'
 import React from 'react'
 
 import { SearchResultItem } from './SearchResultItem'
-import type { SearchResultRecord } from 'types/index'
-
-const testApplicationResult: SearchResultRecord = {
-  id: 'testBookmark123',
-  type: 'Bookmark',
-  title: 'MyFSS',
-  preview:
-    'How is Air Force Information Management System abbreviated? AFIMS stands for Air Force Information Management System. For those who have seen the Earth from space, and for the hundreds and perhaps thousands more who will, the experience most certainly changes your perspective.',
-  permalink: 'https://www.url.com/myfss',
-}
-
-const testArticleResult: SearchResultRecord = {
-  id: 'testArticle123',
-  type: 'Article',
-  title:
-    'Physical training: Everything you need to know about the update in requirements',
-  preview:
-    'As a steward of almost 9 million acres encompassing forests, prairies, deserts, wetlands, and coastal habitats, the Department of the Air Force recognizes the importance of protecting and sustaining the natural environment.',
-  permalink:
-    'https://localhost:3000/articles/physical-training-everything-you-need-to-know',
-  date: '2022-05-17T13:44:39.796Z',
-}
-
-const testDocumentationResult: SearchResultRecord = {
-  id: 'testDocumentation123',
-  type: 'Documentation',
-  title: 'Some Documentation',
-  preview:
-    'Documentation posted about some important topic that you should read about.',
-  permalink: 'https://www.url.com/myfss',
-}
+import {
+  testApplicationResult,
+  testArticleResultNoLabels,
+  testDocumentationResult,
+} from '__fixtures__/data/searchResults'
 
 describe('SearchResultItem component', () => {
   test('renders an Application result with no a11y violations', async () => {
@@ -67,7 +41,9 @@ describe('SearchResultItem component', () => {
   })
 
   test('renders an Article result with no a11y violations', async () => {
-    const { container } = render(<SearchResultItem item={testArticleResult} />)
+    const { container } = render(
+      <SearchResultItem item={testArticleResultNoLabels} />
+    )
 
     expect(screen.queryByText('May')).toBeInTheDocument()
     expect(screen.queryByText('17')).toBeInTheDocument()
@@ -76,12 +52,14 @@ describe('SearchResultItem component', () => {
     expect(screen.queryAllByRole('link')).toHaveLength(1)
     expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
       'href',
-      testArticleResult.permalink
+      testArticleResultNoLabels.permalink
     )
     expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
-      testArticleResult.title
+      testArticleResultNoLabels.title
     )
-    expect(screen.queryByText(testArticleResult.preview)).toBeInTheDocument()
+    expect(
+      screen.queryByText(testArticleResultNoLabels.preview)
+    ).toBeInTheDocument()
     expect(screen.queryByText('USSF News')).toHaveClass('usa-tag')
 
     // Bug with NextJS Link + axe :(

--- a/src/components/SearchResultItem/SearchResultItem.test.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.test.tsx
@@ -11,6 +11,7 @@ import {
   testApplicationResult,
   testArticleResultNoLabels,
   testDocumentationResult,
+  testLandingPageResult,
 } from '__fixtures__/data/searchResults'
 
 describe('SearchResultItem component', () => {
@@ -87,6 +88,32 @@ describe('SearchResultItem component', () => {
       screen.queryByText(testDocumentationResult.preview)
     ).toBeInTheDocument()
     expect(screen.queryByText('USSF Documentation')).toHaveClass('usa-tag')
+
+    // Bug with NextJS Link + axe :(
+    // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
+    await act(async () => {
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
+
+  test('renders a Landing Page result with no a11y violations', async () => {
+    const { container } = render(
+      <SearchResultItem item={testLandingPageResult} />
+    )
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(1)
+    expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
+      'href',
+      testLandingPageResult.permalink
+    )
+    expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
+      testLandingPageResult.title
+    )
+    expect(
+      screen.queryByText(testLandingPageResult.preview)
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Landing Page')).toHaveClass('usa-tag')
 
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334

--- a/src/components/SearchResultItem/SearchResultItem.test.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.test.tsx
@@ -30,58 +30,89 @@ const testArticleResult: SearchResultRecord = {
   date: '2022-05-17T13:44:39.796Z',
 }
 
+const testDocumentationResult: SearchResultRecord = {
+  id: 'testDocumentation123',
+  type: 'Documentation',
+  title: 'Some Documentation',
+  preview:
+    'Documentation posted about some important topic that you should read about.',
+  permalink: 'https://www.url.com/myfss',
+}
+
 describe('SearchResultItem component', () => {
-  it('renders an Application result with no a11y violations', async () => {
+  test('renders an Application result with no a11y violations', async () => {
+    const { container } = render(
+      <SearchResultItem item={testApplicationResult} />
+    )
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(1)
+    expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
+      'href',
+      testApplicationResult.permalink
+    )
+    expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
+      testApplicationResult.title
+    )
+    expect(
+      screen.queryByText(testApplicationResult.preview)
+    ).toBeInTheDocument()
+    expect(screen.queryByText('Application')).toHaveClass('usa-tag')
+
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
-      const { container } = render(
-        <SearchResultItem item={testApplicationResult} />,
-        { legacyRoot: true }
-      )
-
-      expect(screen.queryByRole('img')).not.toBeInTheDocument()
-      expect(screen.queryAllByRole('link')).toHaveLength(1)
-      expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
-        'href',
-        testApplicationResult.permalink
-      )
-      expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
-        testApplicationResult.title
-      )
-      expect(
-        screen.queryByText(testApplicationResult.preview)
-      ).toBeInTheDocument()
-      expect(screen.queryByText('Application')).toHaveClass('usa-tag')
-
       expect(await axe(container)).toHaveNoViolations()
     })
   })
 
-  it('renders an Article result with no a11y violations', async () => {
+  test('renders an Article result with no a11y violations', async () => {
+    const { container } = render(<SearchResultItem item={testArticleResult} />)
+
+    expect(screen.queryByText('May')).toBeInTheDocument()
+    expect(screen.queryByText('17')).toBeInTheDocument()
+
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(1)
+    expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
+      'href',
+      testArticleResult.permalink
+    )
+    expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
+      testArticleResult.title
+    )
+    expect(screen.queryByText(testArticleResult.preview)).toBeInTheDocument()
+    expect(screen.queryByText('USSF News')).toHaveClass('usa-tag')
+
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
-      const { container } = render(
-        <SearchResultItem item={testArticleResult} />,
-        { legacyRoot: true }
-      )
+      expect(await axe(container)).toHaveNoViolations()
+    })
+  })
 
-      expect(screen.queryByText('May')).toBeInTheDocument()
-      expect(screen.queryByText('17')).toBeInTheDocument()
+  test('renders a Documentation result with no a11y violations', async () => {
+    const { container } = render(
+      <SearchResultItem item={testDocumentationResult} />
+    )
 
-      expect(screen.queryByRole('img')).not.toBeInTheDocument()
-      expect(screen.queryAllByRole('link')).toHaveLength(1)
-      expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
-        'href',
-        testArticleResult.permalink
-      )
-      expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
-        testArticleResult.title
-      )
-      expect(screen.queryByText(testArticleResult.preview)).toBeInTheDocument()
-      expect(screen.queryByText('USSF News')).toHaveClass('usa-tag')
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(screen.queryAllByRole('link')).toHaveLength(1)
+    expect(screen.queryAllByRole('link')[0]).toHaveAttribute(
+      'href',
+      testDocumentationResult.permalink
+    )
+    expect(screen.queryByRole('heading', { level: 3 })).toHaveTextContent(
+      testDocumentationResult.title
+    )
+    expect(
+      screen.queryByText(testDocumentationResult.preview)
+    ).toBeInTheDocument()
+    expect(screen.queryByText('USSF Documentation')).toHaveClass('usa-tag')
 
+    // Bug with NextJS Link + axe :(
+    // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
+    await act(async () => {
       expect(await axe(container)).toHaveNoViolations()
     })
   })

--- a/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.tsx
@@ -24,6 +24,9 @@ export const SearchResultItem = ({ item }: { item: SearchResultRecord }) => {
     case 'Documentation':
       itemCategory = CONTENT_CATEGORIES.DOCUMENTATION
       break
+    case 'LandingPage':
+      itemCategory = CONTENT_CATEGORIES.LANDING_PAGE
+      break
   }
 
   return (

--- a/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.tsx
@@ -21,6 +21,9 @@ export const SearchResultItem = ({ item }: { item: SearchResultRecord }) => {
       itemIcon = dateObj && <ArticleDateIcon date={dateObj} />
       break
     }
+    case 'Documentation':
+      itemCategory = CONTENT_CATEGORIES.DOCUMENTATION
+      break
   }
 
   return (

--- a/src/components/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.tsx
@@ -40,7 +40,7 @@ export const SearchResultItem = ({ item }: { item: SearchResultRecord }) => {
           </Link>
         </h3>
 
-        <p>{preview}</p>
+        <p data-testid="result-preview">{preview}</p>
 
         <div className={styles.metadata}>
           {itemCategory && <Category category={itemCategory} />}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -44,6 +44,10 @@ export const CONTENT_CATEGORIES = {
     value: 'Documentation',
     label: 'USSF Documentation',
   },
+  LANDING_PAGE: {
+    value: 'LandingPage',
+    label: 'Landing Page',
+  },
   APPLICATION: {
     value: 'Application',
     label: 'Application',

--- a/src/helpers/index.test.ts
+++ b/src/helpers/index.test.ts
@@ -7,6 +7,7 @@ import {
   isCmsUser,
   getYouTubeEmbedId,
   handleRedirectTo,
+  formatDisplayDate,
 } from './index'
 
 import type { RSSNewsItem, PublishableItemType } from 'types'
@@ -215,5 +216,13 @@ describe('handleRedirectTo', () => {
       body: { RelayState: encodeURIComponent(expectedRedirectTo) },
     } as PassportRequest
     expect(handleRedirectTo(mockReq)).toEqual('/redirect?redirectPath=/users')
+  })
+})
+
+describe('formatDisplayDate', () => {
+  test('returns formatted date string', () => {
+    const testDate = new Date('2021-05-17T13:44:39.796Z')
+    const expectedDate = 'May 17, 2021'
+    expect(formatDisplayDate(testDate)).toEqual(expectedDate)
   })
 })

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -124,3 +124,11 @@ export const handleRedirectTo = (req: PassportRequest) => {
     return '/'
   }
 }
+
+export const formatDisplayDate = (date: Date) => {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/src/operations/cms/queries/getLandingPage.ts
+++ b/src/operations/cms/queries/getLandingPage.ts
@@ -14,6 +14,7 @@ export const GET_LANDING_PAGE = gql`
       slug
       status
       publishedDate
+      updatedAt
       documents {
         title
         document {

--- a/src/pages/landing/[landingPage]/index.tsx
+++ b/src/pages/landing/[landingPage]/index.tsx
@@ -17,7 +17,7 @@ import { GET_LANDING_PAGE } from 'operations/cms/queries/getLandingPage'
 import { CMSBookmark, CollectionRecord } from 'types'
 import { isPdf, handleOpenPdfLink } from 'helpers/openDocumentLink'
 import { getSession } from 'lib/session'
-import { isCmsUser, isPublished } from 'helpers/index'
+import { formatDisplayDate, isCmsUser, isPublished } from 'helpers/index'
 
 type DocumentsType = {
   title: string
@@ -154,6 +154,14 @@ const LandingPage = ({
         {articles.length >= 1 && <h2 id="articles">Articles</h2>}
         {articles.length >= 1 && (
           <ArticleList articles={articles} landingPage={true} />
+        )}
+        {isPublished(landingPage) && (
+          <p>
+            Last updated:{' '}
+            {landingPage.updatedAt >= landingPage.publishedDate
+              ? formatDisplayDate(landingPage.updatedAt)
+              : formatDisplayDate(landingPage.publishedDate)}
+          </p>
         )}
       </>
     )

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -131,9 +131,6 @@ export default Search
 Search.getLayout = (page: React.ReactNode) => withArticleLayout(page)
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  // Need absolute URL
-  const origin = process.env.NEXT_PUBLIC_PORTAL_URL
-
   // get search terms from URL params
   const { q } = context.query
 
@@ -163,22 +160,10 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     variables: { query: q },
   })) as unknown as { data: { search: SearchResultRecord[] } }
 
-  // Add full URL to articles (TODO do this on the CMS end by generating permalinks)
-  const results =
-    search?.map((i) => {
-      return {
-        ...i,
-        permalink:
-          i.type === 'Article'
-            ? `${origin}/articles/${i.permalink}`
-            : i.permalink,
-      }
-    }) || []
-
   return {
     props: {
       query: q,
-      results,
+      results: search ? search : [],
       pageTitle: `${q} Search Results`,
       labels,
     },

--- a/src/stories/searchresults.stories.tsx
+++ b/src/stories/searchresults.stories.tsx
@@ -6,6 +6,7 @@ import {
   testApplicationResult,
   testArticleResult,
   testDocumentationResult,
+  testLandingPageResult,
 } from '__fixtures__/data/searchResults'
 
 export default {
@@ -29,6 +30,7 @@ export const SearchResults = () => {
       />
       <SearchResultItem item={testArticleResult} />
       <SearchResultItem item={testDocumentationResult} />
+      <SearchResultItem item={testLandingPageResult} />
     </>
   )
 }

--- a/src/stories/searchresults.stories.tsx
+++ b/src/stories/searchresults.stories.tsx
@@ -2,39 +2,15 @@ import React from 'react'
 import type { Meta } from '@storybook/react'
 
 import { SearchResultItem } from 'components/SearchResultItem/SearchResultItem'
-import type { SearchResultRecord } from 'types/index'
+import {
+  testApplicationResult,
+  testArticleResult,
+  testDocumentationResult,
+} from '__fixtures__/data/searchResults'
 
 export default {
   title: 'Components/SearchResults',
 } as Meta
-
-const testApplicationResult: SearchResultRecord = {
-  id: 'testBookmark123',
-  type: 'Bookmark',
-  title: 'MyFSS',
-  preview:
-    'How is Air Force Information Management System abbreviated? AFIMS stands for Air Force Information Management System. For those who have seen the Earth from space, and for the hundreds and perhaps thousands more who will, the experience most certainly changes your perspective.',
-  permalink: 'https://www.url.com/myfss',
-}
-
-const testArticleResult: SearchResultRecord = {
-  id: 'testArticle123',
-  type: 'Article',
-  title:
-    'Physical training: Everything you need to know about the update in requirements',
-  preview:
-    'As a steward of almost 9 million acres encompassing forests, prairies, deserts, wetlands, and coastal habitats, the Department of the Air Force recognizes the importance of protecting and sustaining the natural environment.',
-  permalink:
-    'https://localhost:3000/articles/physical-training-everything-you-need-to-know',
-  date: '2022-05-17T13:44:39.796Z',
-  labels: [
-    {
-      id: 'testLabel',
-      name: 'All Guardians',
-      type: 'Audience',
-    },
-  ],
-}
 
 export const SearchResults = () => {
   return (
@@ -51,8 +27,8 @@ export const SearchResults = () => {
             'https://localhost:3000/articles/physical-training-everything-you-need-to-know?asfljaslfkjlkajrlakjsflkajsflasfmaaslkfjalsfjaklsjlasfksfljaslfkjlkajrlakjsflkajsflasfmaaslkfjalsfjaklsjlasfk',
         }}
       />
-
       <SearchResultItem item={testArticleResult} />
+      <SearchResultItem item={testDocumentationResult} />
     </>
   )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,7 +128,11 @@ export type LabelRecord = {
 }
 
 /* Search Results (from Keystone) */
-export type SearchResultType = 'Article' | 'Bookmark' | 'Documentation'
+export type SearchResultType =
+  | 'Article'
+  | 'Bookmark'
+  | 'Documentation'
+  | 'LandingPage'
 
 export type SearchResultRecord = {
   id: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -128,7 +128,7 @@ export type LabelRecord = {
 }
 
 /* Search Results (from Keystone) */
-export type SearchResultType = 'Article' | 'Bookmark'
+export type SearchResultType = 'Article' | 'Bookmark' | 'Documentation'
 
 export type SearchResultRecord = {
   id: string


### PR DESCRIPTION
# SC-2635

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

- CMS returns article permalinks in search result query so we don't need to calculate it anymore

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

- https://github.com/USSF-ORBIT/ussf-portal/pull/353
- https://github.com/USSF-ORBIT/ussf-portal-cms/pull/418

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

- Create a published landing page
- Search by content in description, title, or slug
- Search by using tag short cut `tag:landing-page-tag` or `tag:"beatae quis vel"` if it has spaces.
- Draft landing pages, or pages published in the future will not show up

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
