### PR TITLE
fix: a11y: edit display name component syntax 

### DIFF
--- a/src/__tests__/pages/settings.test.tsx
+++ b/src/__tests__/pages/settings.test.tsx
@@ -57,8 +57,6 @@ describe('Settings page', () => {
 
     test('renders the settings page', () => {
       expect(screen.getAllByText('Settings')).toHaveLength(1)
-
-      expect(screen.getAllByText('Update name and rank:')).toHaveLength(1)
     })
 
     test('has no a11y violations', async () => {

--- a/src/components/EditDisplayName/EditDisplayName.test.tsx
+++ b/src/components/EditDisplayName/EditDisplayName.test.tsx
@@ -42,8 +42,6 @@ describe('EditDisplayName component', () => {
         />
       )
 
-      expect(screen.getAllByText('Update name and rank:')).toHaveLength(1)
-
       expect(
         screen.getAllByText('Current welcome display title:')
       ).toHaveLength(1)

--- a/src/components/EditDisplayName/EditDisplayName.test.tsx
+++ b/src/components/EditDisplayName/EditDisplayName.test.tsx
@@ -46,7 +46,7 @@ describe('EditDisplayName component', () => {
         screen.getAllByText('Current welcome display title:')
       ).toHaveLength(1)
 
-      expect(screen.getAllByText('Update name')).toHaveLength(1)
+      expect(screen.getAllByText('Update display name')).toHaveLength(1)
 
       const inputField = screen.getByTestId('nameInput')
       fireEvent.change(inputField, { target: { value: 'Test Name' } })

--- a/src/components/EditDisplayName/EditDisplayName.tsx
+++ b/src/components/EditDisplayName/EditDisplayName.tsx
@@ -34,14 +34,12 @@ const EditDisplayName = ({
   return (
     <Grid row>
       <Grid col="fill">
-        <h3>Update name and rank:</h3>
-
         <div className={styles.updateNameAndRank}>
           <label htmlFor="something">Current welcome display title:</label>
           <h2>{greeting}</h2>
 
           <label htmlFor="displayName">
-            <strong>*</strong>Update name
+            Update display name <strong aria-hidden="true">*</strong>
           </label>
 
           <Grid row gap={4}>
@@ -49,12 +47,13 @@ const EditDisplayName = ({
               <input
                 className="usa-input"
                 type="text"
-                name="displayName"
+                id="displayName"
                 placeholder="Enter a display name"
                 value={currentDisplayName}
                 maxLength={1000}
                 onChange={(event) => setDisplayName(event.target.value)}
                 data-testid="nameInput"
+                required
               />
             </Grid>
             <Grid row tablet={{ col: true }} gap={5}>
@@ -82,7 +81,7 @@ const EditDisplayName = ({
                   className={styles.successMessage}
                   type="success"
                   headingLevel="h4">
-                  New title has been saved
+                  New display name has been saved
                 </Alert>
               </Grid>
             </Grid>


### PR DESCRIPTION
# SC-3150

## Proposed changes

- remove h3 from the Edit Display Name component, it breaks the heading order and the sequence was weird
- `Update name` label should be `update display name`
- `New display name has been saved` instead of `new title has been saved` in success message
- add `required` attribute to update display name, move asterisk to after the label, corrects `id`/`htmlFor` name connection between the `label` and `input`


## Setup

`yarn storybook`
http://localhost:6006/?path=/story/components-editdisplayname--default-edit-display-name

http://localhost:3000/settings

---

## Screenshots

<img width="740" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/fffdf518-b947-46fd-9e3a-54b353a2fa83">

![image](https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/c5292485-9e9d-4953-a568-83d0455578fb)
