### PR TITLE
fix: a11y:  Guardian Directory field labeling

### DIFF
--- a/src/pages/guardian-directory.tsx
+++ b/src/pages/guardian-directory.tsx
@@ -78,6 +78,7 @@ const GuardianDirectory = () => {
             placeholder="Search Guardian Directory"
             aria-label="Search Guardian Directory"
             size="small"
+            label="Search Guardian Directory"
           />
         </div>
         <div className={styles.resetSearch}>


### PR DESCRIPTION
# SC-3143

## Proposed changes

- adds label attribute to search guardian directory search field to provide an accessible name that provides sufficient context
- related: [new issue in react-uswds](https://github.com/trussworks/react-uswds/issues/2736) to provide accessible name to small search component

## Setup


### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

http://localhost:3000/guardian-directory

---

## Screenshots

<img width="1194" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/1a208997-2a6b-468e-95b2-984375b45b36">

