### PR TITLE
feat: Add additional content to third-party API

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -50,8 +50,8 @@ export PERSONNEL_API_URL=http://localhost:4000
 ##############################
 # Third-Party API Config       #
 ##############################
-export JWKS_URI=https://federation.test.cce.af.mil/oidc/guardian-one/keys
-export ISSUER=https://federation.test.cce.af.mil/oidc/guardian-one
+export JWKS_URI=http://localhost:5001/.well-known/jwks.json
+export ISSUER=http://localhost:5001/.well-known/issuer.json
 
 ###################################
 # Database/Services Configuration #

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -50,9 +50,9 @@ services:
     build:
       context: ../ussf-portal/test-jwt-service/
       dockerfile: Dockerfile
+    env_file: ../ussf-portal/e2e/.envrc.local
     environment:
-      ISSUER: http://test-jwt-issuer:5001/.well-known/issuer.json
-      JWT_DEV_CERT: ${JWT_DEV_CERT}
+      ISSUER: http://localhost:5001/.well-known/issuer.json
     restart: always
     ports:
       - '5001:5001'

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -3,6 +3,7 @@ import type { KeyValueCache } from '@apollo/utils.keyvaluecache'
 import { DateTime } from 'luxon'
 import { print } from 'graphql'
 import { GET_CNOTES } from '../operations/getPublicArticles'
+import { GET_DOCUMENTS } from '../operations/getDocuments'
 
 class ThirdPartyKeystoneAPI extends RESTDataSource {
   override baseURL = process.env.KEYSTONE_URL
@@ -18,6 +19,14 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
         variables: {
           publishedDate,
         },
+      },
+    })
+  }
+
+  async getDocuments() {
+    return this.post(`/api/graphql`, {
+      body: {
+        query: print(GET_DOCUMENTS),
       },
     })
   }

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 import { print } from 'graphql'
 import { GET_CNOTES } from '../operations/getPublicArticles'
 import { GET_DOCUMENTS } from '../operations/getDocuments'
-import { GET_INTERNAL_NEWS_ARTICLES } from '../operations/getInternalNewsArticles'
+import { GET_NEWS_ARTICLES } from '../operations/getNewsArticles'
 import { GET_LANDING_PAGE_ARTICLES } from '../operations/getLandingPageArticles'
 
 class ThirdPartyKeystoneAPI extends RESTDataSource {
@@ -33,10 +33,10 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
     })
   }
 
-  async getInternalNewsArticles(publishedDate: DateTime) {
+  async getNewsArticles(publishedDate: DateTime) {
     return this.post(`/api/graphql`, {
       body: {
-        query: print(GET_INTERNAL_NEWS_ARTICLES),
+        query: print(GET_NEWS_ARTICLES),
         variables: {
           publishedDate,
         },

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -26,7 +26,7 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
   async getDocuments() {
     return this.post(`/api/graphql`, {
       body: {
-        query: print(GET_DOCUMENTS),
+        query: GET_DOCUMENTS,
       },
     })
   }

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -5,6 +5,7 @@ import { print } from 'graphql'
 import { GET_CNOTES } from '../operations/getPublicArticles'
 import { GET_DOCUMENTS } from '../operations/getDocuments'
 import { GET_INTERNAL_NEWS_ARTICLES } from '../operations/getInternalNewsArticles'
+import { GET_LANDING_PAGE_ARTICLES } from '../operations/getLandingPageArticles'
 
 class ThirdPartyKeystoneAPI extends RESTDataSource {
   override baseURL = process.env.KEYSTONE_URL
@@ -36,6 +37,17 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
     return this.post(`/api/graphql`, {
       body: {
         query: print(GET_INTERNAL_NEWS_ARTICLES),
+        variables: {
+          publishedDate,
+        },
+      },
+    })
+  }
+
+  async getLandingPageArticles(publishedDate: DateTime) {
+    return this.post(`/api/graphql`, {
+      body: {
+        query: print(GET_LANDING_PAGE_ARTICLES),
         variables: {
           publishedDate,
         },

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -4,6 +4,7 @@ import { DateTime } from 'luxon'
 import { print } from 'graphql'
 import { GET_CNOTES } from '../operations/getPublicArticles'
 import { GET_DOCUMENTS } from '../operations/getDocuments'
+import { GET_INTERNAL_NEWS_ARTICLES } from '../operations/getInternalNewsArticles'
 
 class ThirdPartyKeystoneAPI extends RESTDataSource {
   override baseURL = process.env.KEYSTONE_URL
@@ -27,6 +28,17 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
     return this.post(`/api/graphql`, {
       body: {
         query: print(GET_DOCUMENTS),
+      },
+    })
+  }
+
+  async getInternalNewsArticles(publishedDate: DateTime) {
+    return this.post(`/api/graphql`, {
+      body: {
+        query: print(GET_INTERNAL_NEWS_ARTICLES),
+        variables: {
+          publishedDate,
+        },
       },
     })
   }

--- a/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
+++ b/src/pages/api/thirdparty/dataSources/thirdPartyKeystone.ts
@@ -26,7 +26,7 @@ class ThirdPartyKeystoneAPI extends RESTDataSource {
   async getDocuments() {
     return this.post(`/api/graphql`, {
       body: {
-        query: GET_DOCUMENTS,
+        query: print(GET_DOCUMENTS),
       },
     })
   }

--- a/src/pages/api/thirdparty/operations/getDocuments.ts
+++ b/src/pages/api/thirdparty/operations/getDocuments.ts
@@ -1,0 +1,16 @@
+import { gql } from 'graphql-tag'
+
+export const GET_DOCUMENTS = gql`
+  query getDocuments {
+    documents {
+      id
+      title
+      description
+      file {
+        filename
+        filesize
+        url
+      }
+    }
+  }
+`

--- a/src/pages/api/thirdparty/operations/getInternalNewsArticles.ts
+++ b/src/pages/api/thirdparty/operations/getInternalNewsArticles.ts
@@ -1,0 +1,30 @@
+import { gql } from 'graphql-tag'
+
+export const GET_INTERNAL_NEWS_ARTICLES = gql`
+  query GetInternalNewsArticles($publishedDate: DateTime) {
+    articles(
+      where: {
+        status: { equals: Published }
+        publishedDate: { lte: $publishedDate }
+        category: { equals: InternalNews }
+      }
+      orderBy: [{ publishedDate: desc }]
+    ) {
+      id
+      title
+      preview
+      publishedDate
+      labels {
+        id
+        name
+        type
+      }
+      body {
+        document
+      }
+      tags {
+        name
+      }
+    }
+  }
+`

--- a/src/pages/api/thirdparty/operations/getLandingPageArticles.ts
+++ b/src/pages/api/thirdparty/operations/getLandingPageArticles.ts
@@ -1,0 +1,30 @@
+import { gql } from 'graphql-tag'
+
+export const GET_LANDING_PAGE_ARTICLES = gql`
+  query GetLandingPageArticles($publishedDate: DateTime) {
+    articles(
+      where: {
+        status: { equals: Published }
+        publishedDate: { lte: $publishedDate }
+        category: { equals: LandingPage }
+      }
+      orderBy: [{ publishedDate: desc }]
+    ) {
+      id
+      title
+      preview
+      publishedDate
+      labels {
+        id
+        name
+        type
+      }
+      body {
+        document
+      }
+      tags {
+        name
+      }
+    }
+  }
+`

--- a/src/pages/api/thirdparty/operations/getNewsArticles.ts
+++ b/src/pages/api/thirdparty/operations/getNewsArticles.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-tag'
 
-export const GET_INTERNAL_NEWS_ARTICLES = gql`
-  query GetInternalNewsArticles($publishedDate: DateTime) {
+export const GET_NEWS_ARTICLES = gql`
+  query GetNewsArticles($publishedDate: DateTime) {
     articles(
       where: {
         status: { equals: Published }

--- a/src/pages/api/thirdparty/resolvers.test.ts
+++ b/src/pages/api/thirdparty/resolvers.test.ts
@@ -118,6 +118,181 @@ describe('GraphQL resolvers', () => {
       expect(data.displayName).toEqual('BERNADETTE CAMPBELL')
     })
   })
+
+  describe('Query.documents', () => {
+    type ResponseData = {
+      documents: {
+        id: string
+        title: string
+        description: string
+        file: {
+          filename: string
+          filesize: number
+          url: string
+        }
+      }[]
+    }
+
+    test('throws an error if unauthenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation(
+        {
+          query: documentsQuery,
+        },
+        {
+          contextValue: serverContext,
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toHaveLength(1)
+    })
+
+    test('returns all documents if authenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation<ResponseData>(
+        {
+          query: gql`
+            query GetDocuments {
+              documents {
+                id
+                title
+                description
+                file {
+                  filename
+                  filesize
+                  url
+                }
+              }
+            }
+          `,
+        },
+        {
+          contextValue: {
+            ...serverContext,
+            userId: newPortalUser.userId,
+          },
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toBeUndefined()
+    })
+  })
+
+  describe('Query.internalNewsArticles', () => {
+    type ResponseData = {
+      internalNewsArticles: {
+        id: string
+        title: string
+        publishedDate: string
+        body: {
+          document: {
+            type: string
+            children: {
+              text: string
+            }[]
+          }[]
+        }
+      }[]
+    }
+
+    test('throws an error if unauthenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation(
+        {
+          query: internalNewsArticlesQuery,
+        },
+        {
+          contextValue: serverContext,
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toHaveLength(1)
+    })
+
+    test('returns all internal news articles if authenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation<ResponseData>(
+        {
+          query: internalNewsArticlesQuery,
+        },
+        {
+          contextValue: {
+            ...serverContext,
+            userId: newPortalUser.userId,
+          },
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toBeUndefined()
+    })
+  })
+
+  describe('Query.landingPageArticles', () => {
+    type ResponseData = {
+      landingPageArticles: {
+        id: string
+        title: string
+        publishedDate: string
+        body: {
+          document: {
+            type: string
+            children: {
+              text: string
+            }[]
+          }[]
+        }
+      }[]
+    }
+
+    test('throws an error if unauthenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation(
+        {
+          query: landingPageArticlesQuery,
+        },
+        {
+          contextValue: serverContext,
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toHaveLength(1)
+    })
+
+    test('returns all landing page articles if authenticated', async () => {
+      const {
+        body: {
+          singleResult: { errors },
+        },
+      } = (await server.executeOperation<ResponseData>(
+        {
+          query: landingPageArticlesQuery,
+        },
+        {
+          contextValue: {
+            ...serverContext,
+            userId: newPortalUser.userId,
+          },
+        }
+      )) as SingleGraphQLResponse<ResponseData>
+
+      expect(errors).toBeUndefined()
+    })
+  })
 })
 
 // This query is what the third-party calls,
@@ -138,6 +313,65 @@ const cNotesQuery = gql`
 const displayNameQuery = gql`
   query GetDisplayName {
     displayName
+  }
+`
+
+const documentsQuery = gql`
+  query GetDocuments {
+    documents {
+      id
+      title
+      description
+      file {
+        filename
+        filesize
+        url
+      }
+    }
+  }
+`
+
+const internalNewsArticlesQuery = gql`
+  query GetInternalNewsArticles {
+    internalNewsArticles {
+      id
+      title
+      preview
+      publishedDate
+      labels {
+        id
+        name
+        type
+      }
+      body {
+        document
+      }
+      tags {
+        name
+      }
+    }
+  }
+`
+
+const landingPageArticlesQuery = gql`
+  query GetLandingPageArticles {
+    landingPageArticles {
+      id
+      title
+      preview
+      publishedDate
+      labels {
+        id
+        name
+        type
+      }
+      body {
+        document
+      }
+      tags {
+        name
+      }
+    }
   }
 `
 

--- a/src/pages/api/thirdparty/resolvers.test.ts
+++ b/src/pages/api/thirdparty/resolvers.test.ts
@@ -39,6 +39,77 @@ describe('GraphQL resolvers', () => {
       return testCNote
     })
 
+    keystoneAPI.getDocuments = jest.fn(async () => {
+      return {
+        data: {
+          documents: [
+            {
+              id: 'ckwz3u58s1835ql974leo1yll',
+              title: 'Test Document',
+              description: 'Test Document Description',
+              file: {
+                filename: 'test.pdf',
+                filesize: 123456,
+                url: 'https://example.com/test.pdf',
+              },
+            },
+          ],
+        },
+      }
+    })
+
+    keystoneAPI.getInternalNewsArticles = jest.fn(async () => {
+      return {
+        data: {
+          internalNewsArticles: [
+            {
+              id: 'ckwz3u58s1835ql974leo1yll',
+              title: 'Test Internal News Article',
+              publishedDate: '2023-11-14T22:14:14.283Z',
+              body: {
+                document: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Lorem ipsum body text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+    })
+
+    keystoneAPI.getLandingPageArticles = jest.fn(async () => {
+      return {
+        data: {
+          landingPageArticles: [
+            {
+              id: 'ckwz3u58s1835ql974leo1yll',
+              title: 'Test Landing Page Article',
+              publishedDate: '2023-11-14T22:14:14.283Z',
+              body: {
+                document: [
+                  {
+                    type: 'paragraph',
+                    children: [
+                      {
+                        text: 'Lorem ipsum body text',
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      }
+    })
+
     serverContext = {
       dataSources: {
         keystoneAPI,

--- a/src/pages/api/thirdparty/resolvers.test.ts
+++ b/src/pages/api/thirdparty/resolvers.test.ts
@@ -58,7 +58,7 @@ describe('GraphQL resolvers', () => {
       }
     })
 
-    keystoneAPI.getInternalNewsArticles = jest.fn(async () => {
+    keystoneAPI.getNewsArticles = jest.fn(async () => {
       return {
         data: {
           internalNewsArticles: [
@@ -255,9 +255,9 @@ describe('GraphQL resolvers', () => {
     })
   })
 
-  describe('Query.internalNewsArticles', () => {
+  describe('Query.newsArticles', () => {
     type ResponseData = {
-      internalNewsArticles: {
+      newsArticles: {
         id: string
         title: string
         publishedDate: string
@@ -279,7 +279,7 @@ describe('GraphQL resolvers', () => {
         },
       } = (await server.executeOperation(
         {
-          query: internalNewsArticlesQuery,
+          query: newsArticlesQuery,
         },
         {
           contextValue: serverContext,
@@ -296,7 +296,7 @@ describe('GraphQL resolvers', () => {
         },
       } = (await server.executeOperation<ResponseData>(
         {
-          query: internalNewsArticlesQuery,
+          query: newsArticlesQuery,
         },
         {
           contextValue: {
@@ -402,9 +402,9 @@ const documentsQuery = gql`
   }
 `
 
-const internalNewsArticlesQuery = gql`
-  query GetInternalNewsArticles {
-    internalNewsArticles {
+const newsArticlesQuery = gql`
+  query GetNewsArticles {
+    newsArticles {
       id
       title
       preview

--- a/src/pages/api/thirdparty/resolvers.ts
+++ b/src/pages/api/thirdparty/resolvers.ts
@@ -62,5 +62,21 @@ export const resolvers = {
 
       return documents
     },
+
+    internalNewsArticles: async (
+      _: undefined,
+      __: undefined,
+      { dataSources: { keystoneAPI }, userId }: ThirdPartyContext
+    ) => {
+      if (!userId) {
+        throw new Error('User not authenticated')
+      }
+
+      const {
+        data: { articles },
+      } = await keystoneAPI.getInternalNewsArticles(DateTime.now())
+
+      return articles
+    },
   },
 }

--- a/src/pages/api/thirdparty/resolvers.ts
+++ b/src/pages/api/thirdparty/resolvers.ts
@@ -78,5 +78,21 @@ export const resolvers = {
 
       return articles
     },
+
+    landingPageArticles: async (
+      _: undefined,
+      __: undefined,
+      { dataSources: { keystoneAPI }, userId }: ThirdPartyContext
+    ) => {
+      if (!userId) {
+        throw new Error('User not authenticated')
+      }
+
+      const {
+        data: { articles },
+      } = await keystoneAPI.getLandingPageArticles(DateTime.now())
+
+      return articles
+    },
   },
 }

--- a/src/pages/api/thirdparty/resolvers.ts
+++ b/src/pages/api/thirdparty/resolvers.ts
@@ -47,5 +47,20 @@ export const resolvers = {
       // Look up user in MongoDB and get their display name
       return UserModel.getDisplayName(userId, { db })
     },
+    documents: async (
+      _: undefined,
+      __: undefined,
+      { dataSources: { keystoneAPI }, userId }: ThirdPartyContext
+    ) => {
+      if (!userId) {
+        throw new Error('User not authenticated')
+      }
+
+      const {
+        data: { documents },
+      } = await keystoneAPI.getDocuments()
+
+      return documents
+    },
   },
 }

--- a/src/pages/api/thirdparty/resolvers.ts
+++ b/src/pages/api/thirdparty/resolvers.ts
@@ -62,7 +62,7 @@ export const resolvers = {
       return documents
     },
 
-    internalNewsArticles: async (
+    newsArticles: async (
       _: undefined,
       __: undefined,
       { dataSources: { keystoneAPI }, userId }: ThirdPartyContext
@@ -73,7 +73,7 @@ export const resolvers = {
 
       const {
         data: { articles },
-      } = await keystoneAPI.getInternalNewsArticles(DateTime.now())
+      } = await keystoneAPI.getNewsArticles(DateTime.now())
 
       return articles
     },

--- a/src/pages/api/thirdparty/schema.ts
+++ b/src/pages/api/thirdparty/schema.ts
@@ -15,8 +15,22 @@ export const typeDefs = gql`
     document(hydrateRelationships: Boolean! = false): JSON!
   }
 
+  type Document {
+    id: ID!
+    title: String!
+    description: String!
+    file: Document_file
+  }
+
+  type Document_file {
+    filename: String!
+    filesize: Int!
+    url: String!
+  }
+
   type Query {
     cNotes: [CNote!]
     displayName: String!
+    documents: [Document!]
   }
 `

--- a/src/pages/api/thirdparty/schema.ts
+++ b/src/pages/api/thirdparty/schema.ts
@@ -28,27 +28,27 @@ export const typeDefs = gql`
     url: String!
   }
 
-  type InternalNewsArticle {
+  type NewsArticle {
     id: ID!
     title: String!
     preview: String!
     publishedDate: String!
-    labels: [InternalNewsArticleLabel!]
-    body: InternalNewsArticle_body_Document
-    tags: [InternalNewsArticleTag!]
+    labels: [NewsArticleLabel!]
+    body: NewsArticle_body_Document
+    tags: [NewsArticleTag!]
   }
 
-  type InternalNewsArticleLabel {
+  type NewsArticleLabel {
     id: ID!
     name: String!
     type: String!
   }
 
-  type InternalNewsArticle_body_Document {
+  type NewsArticle_body_Document {
     document(hydrateRelationships: Boolean! = false): JSON!
   }
 
-  type InternalNewsArticleTag {
+  type NewsArticleTag {
     name: String!
   }
 
@@ -80,7 +80,7 @@ export const typeDefs = gql`
     cNotes: [CNote!]
     displayName: String!
     documents: [Document!]
-    internalNewsArticles: [InternalNewsArticle!]
+    newsArticles: [NewsArticle!]
     landingPageArticles: [LandingPageArticle!]
   }
 `

--- a/src/pages/api/thirdparty/schema.ts
+++ b/src/pages/api/thirdparty/schema.ts
@@ -52,10 +52,35 @@ export const typeDefs = gql`
     name: String!
   }
 
+  type LandingPageArticle {
+    id: ID!
+    title: String!
+    preview: String!
+    publishedDate: String!
+    labels: [LandingPageArticleLabel!]
+    body: LandingPageArticle_body_Document
+    tags: [LandingPageArticleTag!]
+  }
+
+  type LandingPageArticleLabel {
+    id: ID!
+    name: String!
+    type: String!
+  }
+
+  type LandingPageArticle_body_Document {
+    document(hydrateRelationships: Boolean! = false): JSON!
+  }
+
+  type LandingPageArticleTag {
+    name: String!
+  }
+
   type Query {
     cNotes: [CNote!]
     displayName: String!
     documents: [Document!]
     internalNewsArticles: [InternalNewsArticle!]
+    landingPageArticles: [LandingPageArticle!]
   }
 `

--- a/src/pages/api/thirdparty/schema.ts
+++ b/src/pages/api/thirdparty/schema.ts
@@ -28,9 +28,34 @@ export const typeDefs = gql`
     url: String!
   }
 
+  type InternalNewsArticle {
+    id: ID!
+    title: String!
+    preview: String!
+    publishedDate: String!
+    labels: [InternalNewsArticleLabel!]
+    body: InternalNewsArticle_body_Document
+    tags: [InternalNewsArticleTag!]
+  }
+
+  type InternalNewsArticleLabel {
+    id: ID!
+    name: String!
+    type: String!
+  }
+
+  type InternalNewsArticle_body_Document {
+    document(hydrateRelationships: Boolean! = false): JSON!
+  }
+
+  type InternalNewsArticleTag {
+    name: String!
+  }
+
   type Query {
     cNotes: [CNote!]
     displayName: String!
     documents: [Document!]
+    internalNewsArticles: [InternalNewsArticle!]
   }
 `


### PR DESCRIPTION
# SC-3054

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
- Add CMS Documents to third-party API for authenticated users
- Add InternalNews and LandingPage articles to third-party API for authenticated users
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes
You will need to create some articles on your local machine with the categories `InternalNews` and `LandingPage`
You will also need to follow the instructions for [generating a JWT](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/generate-jwt-token.md)
- I've update the Postman collection and posted it in Slack
- After generating your token, you will find the new endpoints under `USSF Third Party API` > `Auth` in the Postman collection
<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
