### PR TITLE
chore: review launchdarkly flags

### DIFF
--- a/src/__tests__/pages/search.test.tsx
+++ b/src/__tests__/pages/search.test.tsx
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { screen } from '@testing-library/react'
-import { mockFlags } from 'jest-launchdarkly-mock'
 import type { GetServerSidePropsContext } from 'next'
 
 import { renderWithAuth } from '../../testHelpers'
@@ -133,10 +132,6 @@ describe('Search page', () => {
     })
 
     test('renders the SearchFilter component', () => {
-      mockFlags({
-        searchPageFilter: true,
-      })
-
       renderWithAuth(
         <SearchPage
           query="fitness"
@@ -146,22 +141,6 @@ describe('Search page', () => {
       )
 
       expect(screen.getByText('Filter Search')).toBeInTheDocument()
-    })
-
-    test('does not render the SearchFilter component if the flag is off', () => {
-      mockFlags({
-        searchPageFilter: false,
-      })
-
-      renderWithAuth(
-        <SearchPage
-          query="fitness"
-          results={[]}
-          labels={[{ name: 'label1' }, { name: 'label2' }, { name: 'label3' }]}
-        />
-      )
-
-      expect(screen.queryByText('Filter Search')).not.toBeInTheDocument()
     })
 
     test('renders the results if there were matches for the query', async () => {

--- a/src/components/AddWidget/AddWidget.test.tsx
+++ b/src/components/AddWidget/AddWidget.test.tsx
@@ -188,10 +188,6 @@ describe('AddWidget component', () => {
   })
 
   test('Add weather widget', async () => {
-    mockFlags({
-      weatherWidget: true,
-    })
-
     const user = userEvent.setup()
     const mockSetTemporaryWidget = jest.fn()
     const mockIsAddingWidget = jest.fn()
@@ -220,10 +216,6 @@ describe('AddWidget component', () => {
   })
 
   test('Add weather widget button is disabled if the user cannot add Weather', async () => {
-    mockFlags({
-      weatherWidget: true,
-    })
-
     const user = userEvent.setup()
     const mockSetTemporaryWidget = jest.fn()
     const mockIsAddingWidget = jest.fn()

--- a/src/components/AddWidget/AddWidget.tsx
+++ b/src/components/AddWidget/AddWidget.tsx
@@ -89,18 +89,16 @@ const AddWidget = ({
           }}>
           Add news widget
         </Button>
-        {flags?.weatherWidget && (
-          <Button
-            disabled={!canAddWeather}
-            type="button"
-            onClick={() => {
-              setTemporaryWidget('Weather')
-              setIsAddingWidget(true)
-              setIsDropdownOpen(false)
-            }}>
-            Add weather widget
-          </Button>
-        )}
+        <Button
+          disabled={!canAddWeather}
+          type="button"
+          onClick={() => {
+            setTemporaryWidget('Weather')
+            setIsAddingWidget(true)
+            setIsDropdownOpen(false)
+          }}>
+          Add weather widget
+        </Button>
         {flags?.guardianIdealCarousel && (
           <Button
             disabled={!canAddGuardianIdeal}

--- a/src/components/AddWidget/AddWidget.tsx
+++ b/src/components/AddWidget/AddWidget.tsx
@@ -110,17 +110,15 @@ const AddWidget = ({
             Add Guardian Ideal widget
           </Button>
         )}
-        {flags?.featuredShortcuts && (
-          <Button
-            disabled={!canAddFeaturedShortcuts}
-            type="button"
-            onClick={() => {
-              addFeaturedShortcuts()
-              setIsDropdownOpen(false)
-            }}>
-            Add Featured Shortcuts widget
-          </Button>
-        )}
+        <Button
+          disabled={!canAddFeaturedShortcuts}
+          type="button"
+          onClick={() => {
+            addFeaturedShortcuts()
+            setIsDropdownOpen(false)
+          }}>
+          Add Featured Shortcuts widget
+        </Button>
       </DropdownMenu>
     </div>
   )

--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -144,7 +144,7 @@ const MySpace = ({ bookmarks }: { bookmarks: CMSBookmark[] }) => {
               strategy={rectSortingStrategy}>
               <Grid row gap={2}>
                 {mySpace.map((widget: Widget) => {
-                  if (isFeaturedShortcuts(widget) && flags?.featuredShortcuts) {
+                  if (isFeaturedShortcuts(widget)) {
                     return (
                       <Grid
                         key={`widget_${widget._id}`}

--- a/src/components/MySpace/MySpace.tsx
+++ b/src/components/MySpace/MySpace.tsx
@@ -183,7 +183,7 @@ const MySpace = ({ bookmarks }: { bookmarks: CMSBookmark[] }) => {
                     )
                   }
 
-                  if (isWeather(widget) && flags?.weatherWidget) {
+                  if (isWeather(widget)) {
                     const weatherWidget = widget as WeatherWidgetType
                     return (
                       <Grid

--- a/src/components/PageNav/PageNav.test.tsx
+++ b/src/components/PageNav/PageNav.test.tsx
@@ -32,7 +32,6 @@ describe('PageNav component', () => {
 
     test('renders nav items behind LaunchDarkly flags', () => {
       mockFlags({
-        landingPageIndex: true,
         guardianDirectory: true,
       })
 

--- a/src/components/PageNav/PageNav.test.tsx
+++ b/src/components/PageNav/PageNav.test.tsx
@@ -26,14 +26,6 @@ describe('PageNav component', () => {
         expect(link).toHaveAttribute('href', navItem.getAttribute('href'))
       })
 
-      expect(links).toHaveLength(3)
-    })
-
-    test('renders nav items behind LaunchDarkly flags', () => {
-      render(<PageNav />)
-
-      const links = screen.getAllByRole('link')
-
       expect(links).toHaveLength(5)
     })
   })

--- a/src/components/PageNav/PageNav.test.tsx
+++ b/src/components/PageNav/PageNav.test.tsx
@@ -3,7 +3,6 @@
  */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { mockFlags } from 'jest-launchdarkly-mock'
 import PageNav from './PageNav'
 
 jest.mock('next/router', () => ({
@@ -31,10 +30,6 @@ describe('PageNav component', () => {
     })
 
     test('renders nav items behind LaunchDarkly flags', () => {
-      mockFlags({
-        guardianDirectory: true,
-      })
-
       render(<PageNav />)
 
       const links = screen.getAllByRole('link')

--- a/src/components/PageNav/PageNav.tsx
+++ b/src/components/PageNav/PageNav.tsx
@@ -15,6 +15,7 @@ const PageNav = () => {
       label: <>All sites &amp; applications</>,
     },
     { path: '/ussf-documentation', label: 'USSF documentation' },
+    { path: '/landing', label: 'Landing Pages' },
   ]
 
   if (flags.guardianDirectory) {
@@ -23,10 +24,6 @@ const PageNav = () => {
       path: '/guardian-directory',
       label: 'Guardian Directory',
     })
-  }
-
-  if (flags.landingPageIndex) {
-    navItems.push({ path: '/landing', label: 'Landing Pages' })
   }
 
   const items = navItems.map((i) => (

--- a/src/components/PageNav/PageNav.tsx
+++ b/src/components/PageNav/PageNav.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { SideNav } from '@trussworks/react-uswds'
-import { useFlags } from 'launchdarkly-react-client-sdk'
 import styles from './PageNav.module.scss'
 
 import NavLink from 'components/util/NavLink/NavLink'
 
 const PageNav = () => {
-  const flags = useFlags()
-
   const navItems = [
     { path: '/', label: 'My Space' },
+    {
+      path: '/guardian-directory',
+      label: 'Guardian Directory',
+    },
     {
       path: '/sites-and-applications',
       label: <>All sites &amp; applications</>,
@@ -17,14 +18,6 @@ const PageNav = () => {
     { path: '/ussf-documentation', label: 'USSF documentation' },
     { path: '/landing', label: 'Landing Pages' },
   ]
-
-  if (flags.guardianDirectory) {
-    // TODO: we can remove this if and put the navItem in the correct slot above once fully released
-    navItems.splice(1, 0, {
-      path: '/guardian-directory',
-      label: 'Guardian Directory',
-    })
-  }
 
   const items = navItems.map((i) => (
     <NavLink

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -33,7 +33,7 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
 
   return (
     <div ref={setNodeRef} style={{ ...style }}>
-      {disableDragAndDrop || !dragAndDropCollections ? (
+      {disableDragAndDrop || true ? (
         <div>{children}</div>
       ) : (
         <div

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -9,14 +9,8 @@ type DraggableWidgetProps = {
 }
 
 const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: id })
+  const { listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: id })
 
   const style = {
     transform: CSS.Translate.toString(transform),
@@ -35,7 +29,6 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
       ) : (
         <div
           {...listeners}
-          {...attributes}
           style={{
             cursor: isDragging ? 'grabbing' : 'grab',
           }}>

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { useFlags } from 'launchdarkly-react-client-sdk'
 import { useMySpaceContext } from 'stores/myspaceContext'
 
 type DraggableWidgetProps = {
@@ -18,6 +19,8 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
     isDragging,
   } = useSortable({ id: id })
 
+  const { dragAndDropCollections } = useFlags()
+
   const style = {
     transform: CSS.Translate.toString(transform),
     transition,
@@ -30,7 +33,7 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
 
   return (
     <div ref={setNodeRef} style={{ ...style }}>
-      {disableDragAndDrop ? (
+      {disableDragAndDrop || !dragAndDropCollections ? (
         <div>{children}</div>
       ) : (
         <div

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useFlags } from 'launchdarkly-react-client-sdk'
 import { useMySpaceContext } from 'stores/myspaceContext'
 
 type DraggableWidgetProps = {
@@ -19,8 +18,6 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
     isDragging,
   } = useSortable({ id: id })
 
-  const { dragAndDropCollections } = useFlags()
-
   const style = {
     transform: CSS.Translate.toString(transform),
     transition,
@@ -33,7 +30,7 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
 
   return (
     <div ref={setNodeRef} style={{ ...style }}>
-      {disableDragAndDrop || !dragAndDropCollections ? (
+      {disableDragAndDrop ? (
         <div>{children}</div>
       ) : (
         <div

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useFlags } from 'launchdarkly-react-client-sdk'
 import { useMySpaceContext } from 'stores/myspaceContext'
 
 type DraggableWidgetProps = {
@@ -18,8 +17,6 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
     transition,
     isDragging,
   } = useSortable({ id: id })
-
-  const { dragAndDropCollections } = useFlags()
 
   const style = {
     transform: CSS.Translate.toString(transform),

--- a/src/components/util/DraggableWidget/DraggableWidget.tsx
+++ b/src/components/util/DraggableWidget/DraggableWidget.tsx
@@ -30,7 +30,7 @@ const DraggableWidget = ({ id, children }: DraggableWidgetProps) => {
 
   return (
     <div ref={setNodeRef} style={{ ...style }}>
-      {disableDragAndDrop || true ? (
+      {disableDragAndDrop ? (
         <div>{children}</div>
       ) : (
         <div

--- a/src/pages/guardian-directory.tsx
+++ b/src/pages/guardian-directory.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useFlags } from 'launchdarkly-react-client-sdk'
-import { useRouter } from 'next/router'
 import { Button, Search } from '@trussworks/react-uswds'
 import LoadingWidget from 'components/LoadingWidget/LoadingWidget'
 import { withDefaultLayout } from 'layout/DefaultLayout/DefaultLayout'
@@ -12,8 +10,6 @@ import { GuardianDirectory as GuardianDirectoryType } from 'types'
 import { useGetGuardianDirectoryQuery } from 'operations/portal/queries/getGuardianDirectory.g'
 
 const GuardianDirectory = () => {
-  const flags = useFlags()
-  const router = useRouter()
   const [directory, setDirectory] = useState(Array<GuardianDirectoryType>)
   const { data: lastModifiedAt } = useGetLastModifiedAtQuery()
   const { data: guardianDirectoryData, loading: loadingGuardianData } =
@@ -60,12 +56,6 @@ const GuardianDirectory = () => {
     searchInput.value = ''
     // reset the search query
     setSearchQuery(' ')
-  }
-
-  // TODO: remove once released
-  // If guardian directory is off return 404
-  if (flags.guardianDirectory === false) {
-    router.replace('/404')
   }
 
   return (

--- a/src/pages/search.tsx
+++ b/src/pages/search.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next'
 import { GridContainer, Grid } from '@trussworks/react-uswds'
-import { useFlags } from 'launchdarkly-react-client-sdk'
 import { client } from 'lib/keystoneClient'
 import { withArticleLayout } from 'layout/DefaultLayout/ArticleLayout'
 import PageHeader from 'components/PageHeader/PageHeader'
@@ -27,7 +26,6 @@ const Search = ({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const { loading } = useUser()
   const { setSearchQuery } = useSearchContext()
-  const flags = useFlags()
 
   // If a query is passed in, set the searchQuery state to that value
   useEffect(() => {
@@ -78,7 +76,7 @@ const Search = ({
         <Grid row gap="lg">
           <Grid col="auto">
             <EPubsCard query={query} />
-            {flags?.searchPageFilter && <SearchFilter labels={labels} />}
+            <SearchFilter labels={labels} />
           </Grid>
 
           {results.length > 0 ? (

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -8,5 +8,4 @@ export default {
   sitesAppsSortView: false,
   featuredShortcuts: true,
   searchPageFilter: true,
-  dragAndDropCollections: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -6,5 +6,4 @@
 export default {
   guardianIdealCarousel: true,
   sitesAppsSortView: false,
-  dragAndDropCollections: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -4,16 +4,10 @@
  * server to see changes.
  */
 export default {
-  // FIX: released
   guardianIdealCarousel: true,
-  // FIX: released
   featuredShortcuts: true,
-  // FIX: released
   searchPageFilter: true,
-  // FIX: released
   dragAndDropCollections: true,
-  // FIX: released
   weatherWidget: true,
-  // FIX: released
   sitesAppsSortView: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -7,5 +7,4 @@ export default {
   guardianIdealCarousel: true,
   sitesAppsSortView: false,
   featuredShortcuts: true,
-  searchPageFilter: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -5,9 +5,9 @@
  */
 export default {
   guardianIdealCarousel: true,
+  sitesAppsSortView: false,
   featuredShortcuts: true,
   searchPageFilter: true,
   dragAndDropCollections: true,
   weatherWidget: true,
-  sitesAppsSortView: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -6,4 +6,5 @@
 export default {
   guardianIdealCarousel: true,
   sitesAppsSortView: false,
+  dragAndDropCollections: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -9,5 +9,4 @@ export default {
   featuredShortcuts: true,
   searchPageFilter: true,
   dragAndDropCollections: true,
-  weatherWidget: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -4,11 +4,18 @@
  * server to see changes.
  */
 export default {
+  // FIX: released
   guardianIdealCarousel: true,
+  // FIX: released
   guardianDirectory: true,
+  // FIX: released
   featuredShortcuts: true,
+  // FIX: released
   searchPageFilter: true,
+  // FIX: released
   dragAndDropCollections: true,
+  // FIX: released
   weatherWidget: true,
-  landingPageIndex: true,
+  // FIX: released
+  sitesAppsSortView: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -6,5 +6,4 @@
 export default {
   guardianIdealCarousel: true,
   sitesAppsSortView: false,
-  featuredShortcuts: true,
 }

--- a/src/stores/launchDarklyLocal.ts
+++ b/src/stores/launchDarklyLocal.ts
@@ -7,8 +7,6 @@ export default {
   // FIX: released
   guardianIdealCarousel: true,
   // FIX: released
-  guardianDirectory: true,
-  // FIX: released
   featuredShortcuts: true,
   // FIX: released
   searchPageFilter: true,


### PR DESCRIPTION
# SC-3164

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

<!-- description and/or list of proposed changes -->

Remove LaunchDarkly flags from features we are not going to turn off. Everything should still work the same.

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
