### PR TITLE
fix: adds page title to Guardian Directory page

### DIFF
--- a/src/__tests__/pages/guardian-directory.test.tsx
+++ b/src/__tests__/pages/guardian-directory.test.tsx
@@ -5,7 +5,7 @@
 import { screen, act, waitFor } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { renderWithAuthAndApollo } from '../../testHelpers'
-import GuardianDirectory from 'pages/guardian-directory'
+import GuardianDirectory, { getServerSideProps } from 'pages/guardian-directory'
 import { guardianDirectoryMock } from '__fixtures__/data/guardianDirectory'
 import { SearchGuardianDirectoryDocument } from 'operations/portal/queries/searchGuardianDirectory.g'
 import { GetLastModifiedAtDocument } from 'operations/portal/queries/getLastModifiedAt.g'
@@ -54,6 +54,15 @@ describe('GuardianDirectory', () => {
   })
 
   describe('when logged in', () => {
+    test('returns the page title', async () => {
+      const response = await getServerSideProps()
+      expect(response).toEqual({
+        props: {
+          pageTitle: 'Guardian Directory',
+        },
+      })
+    })
+
     test('renders the documentation page from the cms', async () => {
       renderWithAuthAndApollo(<GuardianDirectory />, {}, mockDirectory)
 

--- a/src/pages/guardian-directory.tsx
+++ b/src/pages/guardian-directory.tsx
@@ -134,3 +134,11 @@ const GuardianDirectory = () => {
 export default GuardianDirectory
 
 GuardianDirectory.getLayout = withDefaultLayout
+
+export async function getServerSideProps() {
+  return {
+    props: {
+      pageTitle: 'Guardian Directory',
+    },
+  }
+}


### PR DESCRIPTION
# SC-3147

## Proposed changes

this branch adds a page title attribute to the Guardian Directory page, ensuring it has a unique page title that explains its purpose. This ensures the page passes Trusted Tester ID [12.B / WCAG standard 2.4.2: page-title-purpose](https://section508coordinators.github.io/TrustedTester/titles.html) passes.

The impact on users is browser tabs with multiple portal pages can be differentiated without having to open the tab to check the content. This is also beneficial to users of assitive technology when navigating between browser tabs.

Related PR explaining Next JS implementation for custom page titles across the system: [ feat: a11y: assigns unique page titles to each page in the portal #1037](https://github.com/USSF-ORBIT/ussf-portal-client/issues/1037)

## Reviewer notes

on other pages, I notice a bunch more content in the server side props where the page title is set. Please take a look to ensure I did not forget something that may be important to our Next implementation.


## Setup


### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal and visit http://localhost:3000/guardian-directory



---

## Screenshots

<img width="465" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/824b411b-7ad9-4de8-b899-560378927c44">

<img width="369" alt="image" src="https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/3e074fc6-fb1a-4120-b42e-841024dc93ad">

