### PR TITLE
fix: a11y: move skip link anchor entry point to unique page content in default layout

### DIFF
--- a/src/layout/DefaultLayout/DefaultLayout.test.tsx
+++ b/src/layout/DefaultLayout/DefaultLayout.test.tsx
@@ -38,14 +38,15 @@ describe('DefaultLayout component options', () => {
 })
 
 describe('DefaultLayout component', () => {
+  let container: HTMLElement
   beforeEach(async () => {
-    renderWithAuthAndApollo(
+    ;({ container } = renderWithAuthAndApollo(
       <DefaultLayout>
         <h1>Test Page</h1>
       </DefaultLayout>,
       {},
       getUserMock
-    )
+    ))
     // need to wait for the query to finish so waiting for banner to display
     await waitFor(() =>
       expect(screen.getByTestId('govBanner')).toBeInTheDocument()
@@ -65,7 +66,7 @@ describe('DefaultLayout component', () => {
       screen.getByRole('link', { name: 'Skip to main content' })
     ).toHaveAttribute('href', '#main-content')
 
-    expect(screen.getByRole('main')).toHaveAttribute('id', 'main-content')
+    expect(container.querySelector('div#main-content')).toBeInTheDocument()
   })
 
   it('renders a feedback link', () => {

--- a/src/layout/DefaultLayout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout/DefaultLayout.tsx
@@ -51,7 +51,7 @@ const DefaultLayout = ({
           <GovBanner tld=".mil" />
           <Header />
         </div>
-        <main id="main-content">
+        <main>
           <PageHeader>
             <PersonalData userDisplayName={displayName} />
           </PageHeader>
@@ -62,7 +62,7 @@ const DefaultLayout = ({
               <Grid desktop={{ col: 2 }} style={{ minWidth: '221px' }}>
                 <PageNav />
               </Grid>
-              <Grid desktop={{ col: true }}>
+              <Grid id="main-content" desktop={{ col: true }}>
                 {/* PAGE CONTENT */}
                 {children}
               </Grid>


### PR DESCRIPTION
# SC-3212

## Proposed changes

this branch edits the `DefaultLayout.tsx` file which is out base for our core functionality pages`My Space`, `Sites & Applications`, `Guardian Directory` that have the left side nave and repeated `PageHeader` component to move the id anchor link for the `Skip to main content` link to direct to. 

This ensures the user can skip right to the unique page content instead of getting directed to the search, side nav, etc. 

This ensures compliance for WCAG 2.0  2.4.1 Bypass success criteria [Trusted Tester ID 9A](https://section508coordinators.github.io/TrustedTester/repetitive.html)


## Reviewer notes
this PR does not make changes to the other page layouts, which appear to be compliant. I am unsure if we should skip the `Page Header` component on the `PageLayout.tsx` layout.

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000
Press `Tab` to expose the `Skip to main content` link and ensure it skips the repeated content we have on other pages, and that it goes directly to our unique page content in all system page layouts.


---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

https://github.com/USSF-ORBIT/ussf-portal-client/assets/59394696/d107e43b-dc60-4bee-8605-cc1d188cd376



