### PR TITLE
fix: Update code to account for params on end of asset url in s3

### DIFF
--- a/src/helpers/openDocumentLink.test.ts
+++ b/src/helpers/openDocumentLink.test.ts
@@ -18,10 +18,10 @@ URL.revokeObjectURL = mockRevokeObjectURL
 const mockWindowOpen = jest.fn()
 window.open = mockWindowOpen
 
-describe('isPdf', () => {
+describe('openDocumentLink', () => {
   Object.entries(mimeTypes).forEach(([extension, type]) => {
-    test('returns correct type if url ends with extension', () => {
-      const fileName = `https://www.google.com/test.${extension}`
+    test('returns correct type if url is hosted on s3', () => {
+      const fileName = `https://www.google.com/test.${extension}?queryparamsands3things`
       expect(getMimeType(fileName)).toBe(type)
     })
   })
@@ -31,11 +31,17 @@ describe('isPdf', () => {
       'application/octet-stream'
     )
   })
+
+  test('returns correct type if url ends with extension', () => {
+    expect(getMimeType('https://www.google.com/test.pdf')).toBe(
+      'application/pdf'
+    )
+  })
 })
 
 describe('handleOpenPdfLink', () => {
   test('opens a new window if the url is a pdf', async () => {
-    const pdfString = 'https://www.google.com/test.pdf'
+    const pdfString = 'https://www.google.com/test.pdf?queryparamsands3things'
     await openFileInNewTab(pdfString)
     expect(axios.get).toHaveBeenCalled()
     expect(mockCreateObjectURL).toHaveBeenCalled()

--- a/src/helpers/openDocumentLink.ts
+++ b/src/helpers/openDocumentLink.ts
@@ -20,8 +20,22 @@ export const mimeTypes: Record<string, string> = {
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   // Add more mappings as needed
 }
+
+export const extractExtensionFromUrl = (url: string): string | null => {
+  // Remove query parameters if there are any
+  const baseUrl = url.split('?')[0].toLowerCase()
+  const extensions = Object.keys(mimeTypes)
+
+  for (const extension of extensions) {
+    if (baseUrl.endsWith(`.${extension}`)) {
+      return extension
+    }
+  }
+  return null
+}
+
 export const getMimeType = (url: string): string => {
-  const extension = url.split('.').pop()?.toLowerCase()
+  const extension = extractExtensionFromUrl(url)
   return mimeTypes[extension || ''] || 'application/octet-stream' // Default MIME type
 }
 // Function to open files in a new tab with TypeScript annotations


### PR DESCRIPTION
# SC-3219

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes

* Fixes extension parsing to work with urls that both end with the extension, and end with additional params (added by s3, in this case).

* Updates tests

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
