### PR TITLE
chore: Change all remaining it to test

### DIFF
--- a/src/__tests__/pages/_error.test.tsx
+++ b/src/__tests__/pages/_error.test.tsx
@@ -29,7 +29,7 @@ describe('custom error page', () => {
     render(<CustomError statusCode={1024} />)
   })
 
-  it('renders the custom error page,', () => {
+  test('renders the custom error page,', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('1024')
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
       'Houston, we have a problem'
@@ -39,7 +39,7 @@ describe('custom error page', () => {
     )
   })
 
-  it('renders a back button', async () => {
+  test('renders a back button', async () => {
     const user = userEvent.setup()
 
     const backButton = screen.getByRole('button', {
@@ -51,7 +51,7 @@ describe('custom error page', () => {
     expect(mockBack).toHaveBeenCalled()
   })
 
-  it('renders feedback links', async () => {
+  test('renders feedback links', async () => {
     const feedbackLink = screen.getByText('feedback@ussforbit.us')
     expect(feedbackLink).toBeVisible()
     expect(feedbackLink).toHaveAttribute('href')
@@ -71,7 +71,7 @@ describe('custom error page', () => {
     )
   })
 
-  it('tests getInitialProps', async () => {
+  test('tests getInitialProps', async () => {
     const getInitialProps = CustomError.getInitialProps
     expect(getInitialProps).toBeDefined()
     expect(getInitialProps).toBeInstanceOf(Function)
@@ -82,7 +82,7 @@ describe('custom error page', () => {
     expect(result).toEqual({ statusCode: 404 })
   })
 
-  it('tests getInitialProps with no statusCode', async () => {
+  test('tests getInitialProps with no statusCode', async () => {
     const getInitialProps = CustomError.getInitialProps
     expect(getInitialProps).toBeDefined()
     expect(getInitialProps).toBeInstanceOf(Function)
@@ -145,7 +145,7 @@ describe('custom error page without status code', () => {
     render(<CustomError />)
   })
 
-  it('renders the custom error page,', () => {
+  test('renders the custom error page,', () => {
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('500')
   })
 })

--- a/src/__tests__/pages/login-notice.test.tsx
+++ b/src/__tests__/pages/login-notice.test.tsx
@@ -11,22 +11,22 @@ describe('LoginNotice page', () => {
     render(<LoginNotice />)
   })
 
-  it('renders the login notice', () => {
+  test('renders the login notice', () => {
     expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
       'Notice'
     )
   })
 
-  it('renders the agree button', () => {
+  test('renders the agree button', () => {
     expect(screen.getByRole('link')).toHaveTextContent('I agree')
   })
 
-  it('returns the LoginLayout in getLayout', () => {
+  test('returns the LoginLayout in getLayout', () => {
     const page = 'page'
     expect(LoginNotice.getLayout(page)).toEqual(<LoginLayout>page</LoginLayout>)
   })
 
-  it('returns the expected props in getServerSideProps', async () => {
+  test('returns the expected props in getServerSideProps', async () => {
     const response = await getStaticProps()
     expect(response).toEqual({
       props: {

--- a/src/__tests__/pages/update-browser.test.tsx
+++ b/src/__tests__/pages/update-browser.test.tsx
@@ -15,7 +15,7 @@ describe('Update browser page', () => {
     render(<UpdateBrowser />)
   })
 
-  it('renders the update browser page,', () => {
+  test('renders the update browser page,', () => {
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
       'I’m sorry, Dave. I’m afraid you can’t use that outdated browser.'
     )
@@ -34,7 +34,7 @@ describe('Update browser page', () => {
     ).toHaveAttribute('href', FIREFOX_DOWNLOAD)
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
@@ -43,7 +43,7 @@ describe('Update browser page', () => {
     })
   })
 
-  it('returns the ErrorLayout in getLayout', () => {
+  test('returns the ErrorLayout in getLayout', () => {
     const page = 'page'
     expect(UpdateBrowser.getLayout(page)).toEqual(
       <ErrorLayout hideNav={true} ieCompat={true}>
@@ -52,7 +52,7 @@ describe('Update browser page', () => {
     )
   })
 
-  it('returns the expected props in getServerSideProps', async () => {
+  test('returns the expected props in getServerSideProps', async () => {
     const response = await getStaticProps()
     expect(response).toEqual({
       props: {

--- a/src/components/AnnouncementDate/AnnouncementDate.test.tsx
+++ b/src/components/AnnouncementDate/AnnouncementDate.test.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import AnnouncementDate from './AnnouncementDate'
 
 describe('AnnouncementDate component', () => {
-  it('renders the component', () => {
+  test('renders the component', () => {
     render(<AnnouncementDate date="2022-05-17T13:44:39.796Z" />)
 
     expect(screen.getByText('17 MAY')).toBeInTheDocument()

--- a/src/components/ArticleDateIcon/ArticleDateIcon.test.tsx
+++ b/src/components/ArticleDateIcon/ArticleDateIcon.test.tsx
@@ -9,20 +9,20 @@ import React from 'react'
 import { ArticleDateIcon } from './ArticleDateIcon'
 
 describe('ArticleDateIcon component', () => {
-  it('renders the given date', async () => {
+  test('renders the given date', async () => {
     const testDate = new Date('May 16 2022')
     render(<ArticleDateIcon date={testDate} />)
     expect(screen.getByText('May')).toBeInTheDocument()
     expect(screen.getByText('16')).toBeInTheDocument()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     const testDate = new Date('May 16 2022')
     const { container } = render(<ArticleDateIcon date={testDate} />)
     expect(await axe(container)).toHaveNoViolations()
   })
 
-  it('renders null if the given date is invalid', async () => {
+  test('renders null if the given date is invalid', async () => {
     const invalidDate = 'May 16 2022' as unknown as Date
     const result = render(<ArticleDateIcon date={invalidDate} />)
 

--- a/src/components/ArticleList/ArticleList.test.tsx
+++ b/src/components/ArticleList/ArticleList.test.tsx
@@ -21,14 +21,14 @@ const testArticle = {
 const testArticles = [testArticle, testArticle, testArticle]
 
 describe('ArticleList component', () => {
-  it('renders a list of articles', () => {
+  test('renders a list of articles', () => {
     render(<ArticleList articles={testArticles} />)
 
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.getAllByRole('listitem')).toHaveLength(3)
   })
 
-  it('displays the Pagination component if pagination props are passed in', async () => {
+  test('displays the Pagination component if pagination props are passed in', async () => {
     render(
       <ArticleList
         articles={testArticles}
@@ -43,7 +43,7 @@ describe('ArticleList component', () => {
     expect(screen.getByRole('link', { name: 'Page 2' })).toBeInTheDocument()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
@@ -52,7 +52,7 @@ describe('ArticleList component', () => {
     })
   })
 
-  it('renders an empty state', () => {
+  test('renders an empty state', () => {
     render(<ArticleList articles={[]} />)
 
     expect(screen.queryByRole('list')).not.toBeInTheDocument()

--- a/src/components/ArticleListItem/ArticleListItem.test.tsx
+++ b/src/components/ArticleListItem/ArticleListItem.test.tsx
@@ -32,7 +32,7 @@ const rssTestArticle = {
 }
 
 describe('ArticleListItem component', () => {
-  it('renders the article preview of a cms article', () => {
+  test('renders the article preview of a cms article', () => {
     render(<ArticleListItem article={cmsTestArticle} />)
 
     expect(screen.getByText('May')).toBeInTheDocument()
@@ -43,7 +43,7 @@ describe('ArticleListItem component', () => {
     expect(screen.getByText('CMS Test Label')).toBeInTheDocument()
   })
 
-  it('cms article has no a11y violations', async () => {
+  test('cms article has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
@@ -52,7 +52,7 @@ describe('ArticleListItem component', () => {
     })
   })
 
-  it('renders the article preview of an rss article', () => {
+  test('renders the article preview of an rss article', () => {
     render(<ArticleListItem article={rssTestArticle} />)
 
     expect(screen.getByText('Aug')).toBeInTheDocument()
@@ -63,7 +63,7 @@ describe('ArticleListItem component', () => {
     expect(screen.getByText(rssTestArticle.sourceName)).toBeInTheDocument()
   })
 
-  it('rss article has no a11y violations', async () => {
+  test('rss article has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {
@@ -72,7 +72,7 @@ describe('ArticleListItem component', () => {
     })
   })
 
-  it('renders the article preview of an rss article', () => {
+  test('renders the article preview of an rss article', () => {
     render(<ArticleListItem article={rssTestArticle} />)
 
     expect(screen.getByText('Aug')).toBeInTheDocument()

--- a/src/components/BreadcrumbNav/BreadcrumbNav.test.tsx
+++ b/src/components/BreadcrumbNav/BreadcrumbNav.test.tsx
@@ -25,7 +25,7 @@ describe('BreadcrumbNav component', () => {
     render(<BreadcrumbNav navItems={navItems} />)
   })
 
-  it('renders links for the non-current nav items', () => {
+  test('renders links for the non-current nav items', () => {
     const links = screen.getAllByRole('link')
 
     expect(links).toHaveLength(1)
@@ -33,7 +33,7 @@ describe('BreadcrumbNav component', () => {
     expect(links[0]).toHaveTextContent(navItems[0].label)
   })
 
-  it('renders the current item as static text', () => {
+  test('renders the current item as static text', () => {
     expect(screen.getByText('News & Announcements')).toBeInstanceOf(
       HTMLLIElement
     )

--- a/src/components/Collection/Collection.test.tsx
+++ b/src/components/Collection/Collection.test.tsx
@@ -29,18 +29,18 @@ describe('Collection component', () => {
       )
     })
 
-    it('renders a title', () => {
+    test('renders a title', () => {
       const title = screen.getByRole('heading', { level: 3 })
       expect(title).toHaveTextContent('Example collection')
     })
 
-    it('renders its children in a list', () => {
+    test('renders its children in a list', () => {
       expect(screen.getByRole('list')).toBeInTheDocument()
       expect(screen.getAllByRole('listitem')).toHaveLength(3)
       expect(screen.getAllByRole('link')).toHaveLength(3)
     })
 
-    it('has no a11y violations', async () => {
+    test('has no a11y violations', async () => {
       // Bug with NextJS Link + axe :(
       // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
       await act(async () => {
@@ -49,7 +49,7 @@ describe('Collection component', () => {
     })
   })
 
-  it('can render a single child', async () => {
+  test('can render a single child', async () => {
     html = render(
       <Collection title="Example collection">
         <Bookmark key="link1" href="#">
@@ -67,7 +67,7 @@ describe('Collection component', () => {
     })
   })
 
-  it('can render a footer node', async () => {
+  test('can render a footer node', async () => {
     const testFooter = <p>Collection footer</p>
 
     html = render(

--- a/src/components/CustomCollection/CustomCollection.test.tsx
+++ b/src/components/CustomCollection/CustomCollection.test.tsx
@@ -180,7 +180,7 @@ describe('CustomCollection component', () => {
     scrollSpy.mockReset()
   })
 
-  it('renders the collection with DndContext', async () => {
+  test('renders the collection with DndContext', async () => {
     render(
       <CustomCollection
         {...exampleCollection}
@@ -198,7 +198,7 @@ describe('CustomCollection component', () => {
     ).toBeInTheDocument()
   })
 
-  it('drags and drops a link with the keyboard', async () => {
+  test('drags and drops a link with the keyboard', async () => {
     // This test works because dnd-kit renders a hidden div with an id=DndLiveRegion that is used for screen readers to announce
     // which bookmark id is being dragged and where it is being dropped.
     const user = userEvent.setup()
@@ -236,7 +236,7 @@ describe('CustomCollection component', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders the collection with delete or edit buttons', async () => {
+  test('renders the collection with delete or edit buttons', async () => {
     render(
       <CustomCollection
         {...exampleCollection}
@@ -268,7 +268,7 @@ describe('CustomCollection component', () => {
     ).toHaveLength(1)
   })
 
-  it('renders an Add Link toggleable form', async () => {
+  test('renders an Add Link toggleable form', async () => {
     const user = userEvent.setup()
 
     render(
@@ -295,7 +295,7 @@ describe('CustomCollection component', () => {
     expect(linkInput).toBeValid()
   })
 
-  it('cancels Add Link action and resets form', async () => {
+  test('cancels Add Link action and resets form', async () => {
     const user = userEvent.setup()
     render(
       <CustomCollection
@@ -321,7 +321,7 @@ describe('CustomCollection component', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('can select Add Custom Link and open the Add Custom Link modal', async () => {
+  test('can select Add Custom Link and open the Add Custom Link modal', async () => {
     const user = userEvent.setup()
     const mockAddLink = jest.fn()
     const mockUpdateModalId = jest.fn()
@@ -371,7 +371,7 @@ describe('CustomCollection component', () => {
     expect(mockUpdateCustomLinkLabel).toHaveBeenCalled()
   })
 
-  it('can add an existing link', async () => {
+  test('can add an existing link', async () => {
     const user = userEvent.setup()
     const mockAddLink = jest.fn()
 
@@ -396,7 +396,7 @@ describe('CustomCollection component', () => {
     expect(mockAddLink).toHaveBeenCalledWith('www.example.com/2', 'SURF', '2')
   })
 
-  it('renders the settings dropdown menu', async () => {
+  test('renders the settings dropdown menu', async () => {
     const user = userEvent.setup()
     render(
       <CustomCollection
@@ -422,7 +422,7 @@ describe('CustomCollection component', () => {
     expect(editItem).toBeInTheDocument()
   })
 
-  it('clicking the delete collection button opens the delete modal', async () => {
+  test('clicking the delete collection button opens the delete modal', async () => {
     const user = userEvent.setup()
     const mockUpdateModalId = jest.fn()
     const mockUpdateModalText = jest.fn()
@@ -464,7 +464,7 @@ describe('CustomCollection component', () => {
     expect(mockUpdateWidget).toHaveBeenCalled()
   })
 
-  it('clicking outside the dropdown menu closes the menu', async () => {
+  test('clicking outside the dropdown menu closes the menu', async () => {
     const user = userEvent.setup()
     const mockRemoveCollection = jest.fn()
 
@@ -500,7 +500,7 @@ describe('CustomCollection component', () => {
     expect(deleteCollection).not.toBeInTheDocument()
   })
 
-  it('clicking the menu button toggles the menu', async () => {
+  test('clicking the menu button toggles the menu', async () => {
     const user = userEvent.setup()
     const mockRemoveCollection = jest.fn()
 
@@ -533,7 +533,7 @@ describe('CustomCollection component', () => {
     expect(deleteCollection).not.toBeInTheDocument()
   })
 
-  it('renders the collection with links from the CMS', () => {
+  test('renders the collection with links from the CMS', () => {
     const { container } = render(
       <CustomCollection
         {...exampleCollection}
@@ -549,13 +549,13 @@ describe('CustomCollection component', () => {
 
   describe('an empty collection', () => {
     const user = userEvent.setup()
-    it('renders a focused input for the title', () => {
+    test('renders a focused input for the title', () => {
       render(<CustomCollection _id={ObjectId()} {...mockHandlers} />)
 
       expect(screen.getByRole('textbox')).toHaveFocus()
     })
 
-    it('can enter a title', async () => {
+    test('can enter a title', async () => {
       const mockEditCollection = jest.fn()
 
       render(
@@ -571,7 +571,7 @@ describe('CustomCollection component', () => {
       expect(mockEditCollection).toHaveBeenCalledWith('My New Collection')
     })
 
-    it('not entering a title deletes the collection', async () => {
+    test('not entering a title deletes the collection', async () => {
       const mockDeleteCollection = jest.fn()
 
       render(
@@ -590,7 +590,7 @@ describe('CustomCollection component', () => {
   })
 
   describe('with 9 bookmarks', () => {
-    it('shows a warning when adding the tenth link', async () => {
+    test('shows a warning when adding the tenth link', async () => {
       const user = userEvent.setup()
       renderWithModalRoot(
         <CustomCollection
@@ -614,7 +614,7 @@ describe('CustomCollection component', () => {
   })
 
   describe('with 10 bookmarks', () => {
-    it('does not allow adding anymore links', async () => {
+    test('does not allow adding anymore links', async () => {
       render(
         <CustomCollection
           {...exampleCollectionWithTen}

--- a/src/components/CustomCollection/EditableCollectionTitle.test.tsx
+++ b/src/components/CustomCollection/EditableCollectionTitle.test.tsx
@@ -10,7 +10,7 @@ import { ObjectId } from 'mongodb'
 import { EditableCollectionTitle } from './EditableCollectionTitle'
 
 describe('EditableCollectionTitle component', () => {
-  it('renders an editable collection title', () => {
+  test('renders an editable collection title', () => {
     render(
       <EditableCollectionTitle
         collectionId={ObjectId()}
@@ -26,7 +26,7 @@ describe('EditableCollectionTitle component', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders a form to edit title if isEditing is true', () => {
+  test('renders a form to edit title if isEditing is true', () => {
     render(
       <EditableCollectionTitle
         collectionId={ObjectId()}
@@ -48,7 +48,7 @@ describe('EditableCollectionTitle component', () => {
   })
 })
 
-it('saves the form', async () => {
+test('saves the form', async () => {
   const user = userEvent.setup()
   const mockHandleOnSave = jest.fn()
   render(
@@ -69,7 +69,7 @@ it('saves the form', async () => {
   expect(mockHandleOnSave).toBeCalledWith('New Title')
 })
 
-it('cancels the form', async () => {
+test('cancels the form', async () => {
   const user = userEvent.setup()
   const mockHandleOnCancel = jest.fn()
   render(

--- a/src/components/CustomCollection/RemovableBookmark.test.tsx
+++ b/src/components/CustomCollection/RemovableBookmark.test.tsx
@@ -20,7 +20,7 @@ describe('RemovableBookmark component', () => {
     jest.useRealTimers()
   })
 
-  it('renders a bookmark with a delete handler', () => {
+  test('renders a bookmark with a delete handler', () => {
     render(
       <RemovableBookmark bookmark={testBookmark} handleRemove={jest.fn()} />
     )
@@ -31,7 +31,7 @@ describe('RemovableBookmark component', () => {
     ).toBeInTheDocument()
   })
 
-  it('renders the bookmark URL if there is no label', () => {
+  test('renders the bookmark URL if there is no label', () => {
     const testBookmarkNoLabel = {
       id: ObjectId(),
       url: 'https://example.com',
@@ -47,7 +47,7 @@ describe('RemovableBookmark component', () => {
     expect(screen.getByRole('link')).toHaveTextContent(testBookmarkNoLabel.url)
   })
 
-  it('allows the delete handler to be undone', async () => {
+  test('allows the delete handler to be undone', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
     jest.useFakeTimers()
 
@@ -85,7 +85,7 @@ describe('RemovableBookmark component', () => {
     expect(mockHandleRemove).not.toHaveBeenCalled()
   })
 
-  it('handles the delete button if not undone', async () => {
+  test('handles the delete button if not undone', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime })
     jest.useFakeTimers()
 

--- a/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -30,18 +30,18 @@ describe('Dropdown Menu ', () => {
     )
   })
 
-  it('renders the children of the menu', () => {
+  test('renders the children of the menu', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(3)
   })
 
-  it('renders the toggle button', async () => {
+  test('renders the toggle button', async () => {
     const user = userEvent.setup()
     expect(screen.getByRole('button')).toHaveTextContent('Toggle Dropdown')
     await user.click(screen.getByRole('button'))
     expect(mockOnClick).toHaveBeenCalled()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     expect(await axe(html.container)).toHaveNoViolations()
   })
 })

--- a/src/components/EPubsCard/EPubsCard.test.tsx
+++ b/src/components/EPubsCard/EPubsCard.test.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import EPubsCard from './EPubsCard'
 
 describe('EPubsCard component', () => {
-  it('renders the card', () => {
+  test('renders the card', () => {
     render(<EPubsCard query="test" />)
 
     expect(screen.getAllByText('Looking for a form?')).toHaveLength(1)

--- a/src/components/FeedbackCard/FeedbackCard.test.tsx
+++ b/src/components/FeedbackCard/FeedbackCard.test.tsx
@@ -12,7 +12,7 @@ import FeedbackCard from './FeedbackCard'
 import * as analyticsHooks from 'stores/analyticsContext'
 
 describe('Feedback Card component', () => {
-  it('renders a feedback card', () => {
+  test('renders a feedback card', () => {
     render(<FeedbackCard />)
 
     expect(
@@ -45,7 +45,7 @@ describe('Feedback Card component', () => {
       render(<FeedbackCard />)
     })
 
-    it("calls trackEvent when clicking 'feedback@ussforbit.us' link", () => {
+    test("calls trackEvent when clicking 'feedback@ussforbit.us' link", () => {
       const link = screen.getByRole('link', { name: 'feedback@ussforbit.us' })
 
       fireEvent.click(link)

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import Footer from './Footer'
 
 describe('Footer component', () => {
-  it('renders the USSF portal header', () => {
+  test('renders the USSF portal header', () => {
     render(<Footer />)
 
     expect(screen.getByRole('img', { name: 'USSF Portal' })).toHaveAttribute(
@@ -18,7 +18,7 @@ describe('Footer component', () => {
     expect(screen.getAllByRole('link')).toHaveLength(17)
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     // Bug with NextJS Link + axe :(
     // https://github.com/nickcolley/jest-axe/issues/95#issuecomment-758921334
     await act(async () => {

--- a/src/components/Loader/Loader.test.tsx
+++ b/src/components/Loader/Loader.test.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import Loader from './Loader'
 
 describe('Loader component', () => {
-  it('renders loading text', () => {
+  test('renders loading text', () => {
     render(<Loader />)
     expect(screen.getByText('Content is loading...')).toBeInTheDocument()
   })

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import Logo from './Logo'
 
 describe('Logo component', () => {
-  it('renders the logo image', () => {
+  test('renders the logo image', () => {
     render(<Logo />)
 
     expect(screen.getByRole('img')).toBeInTheDocument()
@@ -16,7 +16,7 @@ describe('Logo component', () => {
     expect(screen.getByRole('img')).toHaveAttribute('alt', 'USSF Logo')
   })
 
-  it('renders the dark bg logo image', () => {
+  test('renders the dark bg logo image', () => {
     render(<Logo darkBg />)
 
     expect(screen.getByRole('img')).toBeInTheDocument()
@@ -30,7 +30,7 @@ describe('Logo component', () => {
     )
   })
 
-  it('renders the abbreviated logo image', () => {
+  test('renders the abbreviated logo image', () => {
     render(<Logo abbreviated />)
 
     expect(screen.getByRole('img')).toBeInTheDocument()
@@ -41,7 +41,7 @@ describe('Logo component', () => {
     expect(screen.getByRole('img')).toHaveAttribute('alt', 'USSF Logo')
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     const { container } = render(<Logo />)
     expect(await axe(container)).toHaveNoViolations()
   })

--- a/src/components/NewsCarousel/NewsCarousel.test.tsx
+++ b/src/components/NewsCarousel/NewsCarousel.test.tsx
@@ -9,7 +9,7 @@ import '../../__mocks__/mockMatchMedia'
 import NewsCarousel from './NewsCarousel'
 
 describe('NewsCarousel component', () => {
-  it('renders the component with mock articles', () => {
+  test('renders the component with mock articles', () => {
     render(<NewsCarousel articles={cmsPortalNewsArticlesMock} />)
 
     const prevButton = screen.getByTestId('slick-prev')

--- a/src/components/PageHeader/PageHeader.test.tsx
+++ b/src/components/PageHeader/PageHeader.test.tsx
@@ -7,7 +7,7 @@ import { render, screen } from '@testing-library/react'
 import PageHeader from './PageHeader'
 
 describe('PageHeader component', () => {
-  it('renders Search Component', () => {
+  test('renders Search Component', () => {
     render(<PageHeader>Children</PageHeader>)
     const search = screen.getByRole('searchbox', { name: 'Search' })
     expect(search).toBeInTheDocument()

--- a/src/components/SearchBanner/SearchBanner.test.tsx
+++ b/src/components/SearchBanner/SearchBanner.test.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import { SearchBanner } from './SearchBanner'
 
 describe('SearchBanner component', () => {
-  it('renders the icon and children with no a11y violations', async () => {
+  test('renders the icon and children with no a11y violations', async () => {
     const { container } = render(
       <SearchBanner icon={<img src="/assets/images/moon-flag.svg" alt=" " />}>
         <div>

--- a/src/components/SelectableCollection/SelectableCollection.test.tsx
+++ b/src/components/SelectableCollection/SelectableCollection.test.tsx
@@ -35,7 +35,7 @@ const exampleCollection = {
 }
 
 describe('SelectableCollection component', () => {
-  it('renders the collection with disabled links and a select button', () => {
+  test('renders the collection with disabled links and a select button', () => {
     const mockOnSelect = jest.fn()
 
     render(
@@ -63,7 +63,7 @@ describe('SelectableCollection component', () => {
     ).toBeInTheDocument()
   })
 
-  it('clicking the button calls the select handler', async () => {
+  test('clicking the button calls the select handler', async () => {
     const user = userEvent.setup()
     const mockOnSelect = jest.fn()
 
@@ -83,7 +83,7 @@ describe('SelectableCollection component', () => {
     expect(mockOnSelect).toBeCalled()
   })
 
-  it('the select handler is keyboard accessible', async () => {
+  test('the select handler is keyboard accessible', async () => {
     const user = userEvent.setup()
     const mockOnSelect = jest.fn()
 
@@ -105,7 +105,7 @@ describe('SelectableCollection component', () => {
     expect(mockOnSelect).toBeCalled()
   })
 
-  it('has no a11y violations', async () => {
+  test('has no a11y violations', async () => {
     const { container } = render(
       <SelectableCollection
         {...exampleCollection}
@@ -118,7 +118,7 @@ describe('SelectableCollection component', () => {
   })
 
   describe('when selected', () => {
-    it('renders an unselect button that appears on focus', async () => {
+    test('renders an unselect button that appears on focus', async () => {
       const user = userEvent.setup()
       const mockOnSelect = jest.fn()
 
@@ -144,7 +144,7 @@ describe('SelectableCollection component', () => {
       expect(mockOnSelect).toBeCalled()
     })
 
-    it('has no a11y violations', async () => {
+    test('has no a11y violations', async () => {
       const { container } = render(
         <SelectableCollection
           {...exampleCollection}
@@ -158,7 +158,7 @@ describe('SelectableCollection component', () => {
   })
 
   describe('when disabled', () => {
-    it('does not render a button', () => {
+    test('does not render a button', () => {
       const mockOnSelect = jest.fn()
 
       render(
@@ -177,7 +177,7 @@ describe('SelectableCollection component', () => {
       ).not.toBeInTheDocument()
     })
 
-    it('has no a11y violations', async () => {
+    test('has no a11y violations', async () => {
       const { container } = render(
         <SelectableCollection
           {...exampleCollection}

--- a/src/components/Tag/Tag.test.tsx
+++ b/src/components/Tag/Tag.test.tsx
@@ -9,7 +9,7 @@ import { Tag, Label, Category } from './Tag'
 import { CONTENT_CATEGORIES } from 'constants/index'
 
 describe('Tag component', () => {
-  it('renders the tag with no a11y violations', async () => {
+  test('renders the tag with no a11y violations', async () => {
     const { container } = render(<Tag>my tag</Tag>)
 
     expect(screen.queryByText('my tag')).toBeInTheDocument()
@@ -19,7 +19,7 @@ describe('Tag component', () => {
 })
 
 describe('Label component', () => {
-  it('renders the label', async () => {
+  test('renders the label', async () => {
     render(<Label type="Audience">All Guardians</Label>)
 
     expect(screen.queryByText('All Guardians')).toBeInTheDocument()
@@ -28,7 +28,7 @@ describe('Label component', () => {
 })
 
 describe('Category component', () => {
-  it('renders the category with no a11y violations', async () => {
+  test('renders the category with no a11y violations', async () => {
     const { container } = render(
       <Category category={CONTENT_CATEGORIES.ANNOUNCEMENT} />
     )

--- a/src/components/Widget/Widget.test.tsx
+++ b/src/components/Widget/Widget.test.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 import Widget, { WidgetWithSettings } from './Widget'
 
 describe('Widget component', () => {
-  it('renders Widget', () => {
+  test('renders Widget', () => {
     render(
       <Widget header={<h3>Example widget</h3>}>Example widget contents</Widget>
     )

--- a/src/components/util/Flash/Flash.test.tsx
+++ b/src/components/util/Flash/Flash.test.tsx
@@ -10,11 +10,11 @@ import Flash from './Flash'
 describe('Flash component', () => {
   const testFlash = <p>Test flash message</p>
 
-  it('renders its children', () => {
+  test('renders its children', () => {
     render(<Flash handleClear={jest.fn()}>{testFlash}</Flash>)
   })
 
-  it('calls the clear function after a timeout', () => {
+  test('calls the clear function after a timeout', () => {
     jest.useFakeTimers()
 
     const mockHandleClear = jest.fn()
@@ -26,7 +26,7 @@ describe('Flash component', () => {
     expect(mockHandleClear).toHaveBeenCalled()
   })
 
-  it('resets the timeout if the children change', () => {
+  test('resets the timeout if the children change', () => {
     jest.useFakeTimers()
     const mockHandleClear = jest.fn()
 
@@ -45,7 +45,7 @@ describe('Flash component', () => {
     expect(mockHandleClear).toHaveBeenCalled()
   })
 
-  it('clears the timeout when unmounted', () => {
+  test('clears the timeout when unmounted', () => {
     jest.useFakeTimers()
     const mockHandleClear = jest.fn()
 

--- a/src/components/util/ModalPortal.test.tsx
+++ b/src/components/util/ModalPortal.test.tsx
@@ -8,7 +8,7 @@ import React from 'react'
 import ModalPortal from './ModalPortal'
 
 describe('ModalPortal', () => {
-  it('renders nothing if there is no modal root', () => {
+  test('renders nothing if there is no modal root', () => {
     render(
       <ModalPortal>
         <div role="dialog">Test Modal</div>
@@ -18,7 +18,7 @@ describe('ModalPortal', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('renders children into the modal root once mounted', () => {
+  test('renders children into the modal root once mounted', () => {
     const modalContainer = document.createElement('div')
     modalContainer.setAttribute('id', 'modal-root')
 

--- a/src/components/util/NavLink/NavLink.test.tsx
+++ b/src/components/util/NavLink/NavLink.test.tsx
@@ -11,7 +11,7 @@ import NavLink from './NavLink'
 const mockedUseRouter = useRouter as jest.Mock
 
 describe('NavLink component', () => {
-  it('renders the link and props', () => {
+  test('renders the link and props', () => {
     render(
       <NavLink href="/home" className="text-ink">
         Home
@@ -28,7 +28,7 @@ describe('NavLink component', () => {
     expect(link).toBeInstanceOf(HTMLAnchorElement)
   })
 
-  it('does not render the active class if the path is not active', () => {
+  test('does not render the active class if the path is not active', () => {
     mockedUseRouter.mockReturnValueOnce({
       route: '',
       pathname: '/about',
@@ -45,7 +45,7 @@ describe('NavLink component', () => {
     expect(link).not.toHaveClass('usa-current')
   })
 
-  it('renders the active class if the path is active', () => {
+  test('renders the active class if the path is active', () => {
     mockedUseRouter.mockReturnValueOnce({
       route: '',
       pathname: '/about',
@@ -62,7 +62,7 @@ describe('NavLink component', () => {
     expect(link).toHaveClass('usa-current')
   })
 
-  it('renders the active class if the parent path matches', () => {
+  test('renders the active class if the parent path matches', () => {
     mockedUseRouter.mockReturnValueOnce({
       route: '',
       pathname: '/about/subpage',
@@ -79,7 +79,7 @@ describe('NavLink component', () => {
     expect(link).toHaveClass('usa-current')
   })
 
-  it('does not render the active class if a subpage of the parent path', () => {
+  test('does not render the active class if a subpage of the parent path', () => {
     mockedUseRouter.mockReturnValueOnce({
       route: '',
       pathname: '/about',
@@ -97,7 +97,7 @@ describe('NavLink component', () => {
   })
 
   describe('if the exact prop is set', () => {
-    it('does not render the active class if the parent path matches', () => {
+    test('does not render the active class if the parent path matches', () => {
       mockedUseRouter.mockReturnValueOnce({
         route: '',
         pathname: '/about/subpage',
@@ -118,7 +118,7 @@ describe('NavLink component', () => {
       expect(link).not.toHaveClass('usa-current')
     })
 
-    it('renders the active class if the exact path matches', () => {
+    test('renders the active class if the exact path matches', () => {
       mockedUseRouter.mockReturnValueOnce({
         route: '',
         pathname: '/about/subpage',
@@ -140,7 +140,7 @@ describe('NavLink component', () => {
     })
   })
 
-  it('applies a custom active class', () => {
+  test('applies a custom active class', () => {
     mockedUseRouter.mockReturnValueOnce({
       route: '',
       pathname: '/about',
@@ -164,7 +164,7 @@ describe('NavLink component', () => {
 
   describe('if the URL is a URL Object', () => {
     // https://nextjs.org/docs/api-reference/next/link#with-url-object
-    it('does not render the active class if the path is not active', () => {
+    test('does not render the active class if the path is not active', () => {
       mockedUseRouter.mockReturnValueOnce({
         route: '',
         pathname: '/about',
@@ -181,7 +181,7 @@ describe('NavLink component', () => {
       expect(link).not.toHaveClass('usa-current')
     })
 
-    it('renders the active class if the path is active', () => {
+    test('renders the active class if the path is active', () => {
       mockedUseRouter.mockReturnValueOnce({
         route: '',
         pathname: '/about',
@@ -198,7 +198,7 @@ describe('NavLink component', () => {
       expect(link).toHaveClass('usa-current')
     })
 
-    it('does not break if there is no path', () => {
+    test('does not break if there is no path', () => {
       render(
         <NavLink href={{}} className="text-ink">
           Home


### PR DESCRIPTION
# SC-###

<!--
    If applicable, insert the Shortcut story number in the markdown header above.
    The hyperlink will be filled in by GitHub magic ([autolink references](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources))
--->

## Proposed changes
All engineers previously agreed to use the `test` prefix as opposed to `it` for all unit tests. We have been updating each file as we touch it, but now that we are handing the project off, this PR changes all remaining tests to follow the previously established convention.
<!-- description and/or list of proposed changes -->

---

<!--
    Please add/remove/edit any of the template below to fit the needs
    of this specific PR
--->

## Reviewer notes

<!--
    Is there anything you would like reviewers to give additional scrutiny?
--->

## Setup

<!--
    Add any steps or code to run in this section to help others run your code:

    ```sh
    echo "Code goes here"
    ```
--->

### Start the system
```sh
yarn services:up
yarn dev
cd ../ussf-portal-cms
yarn dev
```

Login to the portal http://localhost:3000

### Start storybook

```sh
yarn storybook
```

Login to storybook http://localhost:6006, though the command above should open it for you

---

## Code review steps

### As the original developer, I have

- [ ] Met the acceptance criteria
- [ ] Created new stories in Storybook if applicable
- [ ] Created/modified automated unit tests in Jest
- [ ] Created/modified automated [E2E tests](https://github.com/USSF-ORBIT/ussf-portal)
- [ ] Followed guidelines for zero-downtime deploys, if applicable
- [ ] Use [ANDI](https://www.ssa.gov/accessibility/andi/help/install.html) to check for basic a11y issues

### As a reviewer, I have

Check out our [How to review a pull request](https://github.com/USSF-ORBIT/ussf-portal/blob/main/docs/how-to/review-pull-request.md) document.

---

## Screenshots

<!-- If this PR makes visible interface changes, an image of the finished interface can help reviewers
and casual observers understand the context of the changes.
A before image is optional and can be included at the submitter's discretion.

Consider using an animated image to show an entire workflow.
You may want to use GIPHY CAPTURE for this! 📸

_Please frame images to show useful context but also highlight the affected regions._
--->
