### PR TITLE
chore: Change test to test:unit for the Gitlab migration

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn lint
 
       - name: Run Jest tests
-        run: yarn test --coverage --silent
+        run: yarn test:unit --coverage --silent
 
       - name: Build Storybook
         run: yarn storybook:build

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepare": "husky install",
     "pre-commit": "lint-staged",
     "test:unit": "jest --runInBand --testTimeout=60000",
+    "test": "jest --runInBand --testTimeout=60000",
     "test:watch": "jest --watch  --runInBand --testTimeout=60000",
     "postinstall": "sh ./scripts/copy_uswds_assets.sh",
     "migrate:create": "migrate create --template-file ./migration-template.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "tsc --noEmit && eslint .",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
-    "test": "jest --runInBand --testTimeout=60000",
+    "test:unit": "jest --runInBand --testTimeout=60000",
     "test:watch": "jest --watch  --runInBand --testTimeout=60000",
     "postinstall": "sh ./scripts/copy_uswds_assets.sh",
     "migrate:create": "migrate create --template-file ./migration-template.js",


### PR DESCRIPTION
Change "test" -> "test:unit" for the Gitlab migration.

Not sure how this will interact with existing pipelines, so this PR is only for testing and should not be merged without scrutiny.